### PR TITLE
データ容量設定を個人ごとに変更できるように対応

### DIFF
--- a/HOW_TO_INIT.md
+++ b/HOW_TO_INIT.md
@@ -1,0 +1,20 @@
+# for Cloud Functions Apps
+
+```
+# submodule
+git submodule add git@github.com:yananob/cloud-functions-common _cf-common
+git submodule add git@github.com:yananob/_template-cloudfunctions _template
+```
+
+## GitHub actionでのデプロイ
+
+1. 以下見る https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?hl=ja&inv=1&invt=Abzjyw&supportedpurview=project
+2. 既存のリポジトリの内容を参考に、同じように追加する
+    - Cloud Run Deployer SAに、既存のプリンシプル〜タブで追加する
+コマンドでもできるはずだが、エラーになるので、上記GUIでの設定にしている
+
+## 自動PR作成の許可
+GitHub ActionsがPRを作成できるようにするために、リポジトリの設定で以下を有効にする必要があります。
+1. リポジトリの **Settings** > **Actions** > **General** を開く
+2. **Workflow permissions** セクションで **Allow GitHub Actions to create and approve pull requests** にチェックを入れる
+3. **Save** をクリック

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# iijmio-usage-checker
+
+
+# 開発方針
+
+## 実装方針
+
+- docs/implementation_policy.md を参照する。

--- a/index.php
+++ b/index.php
@@ -27,7 +27,10 @@ function main_http(ServerRequestInterface $request): string
         if (isset($params['iijmio']['users']) && is_array($params['iijmio']['users'])) {
             foreach ($params['iijmio']['users'] as $user) {
                 if (!empty($user['code']) && !empty($user['name'])) {
-                    $users[$user['code']] = $user['name'];
+                    $users[$user['code']] = [
+                        'name' => $user['name'],
+                        'plan_data_volume' => (float)($user['plan_data_volume'] ?? 0),
+                    ];
                 }
             }
         }
@@ -36,7 +39,6 @@ function main_http(ServerRequestInterface $request): string
             'iijmio' => [
                 'mio_id' => $params['iijmio']['mio_id'] ?? '',
                 'password' => $params['iijmio']['password'] ?? '',
-                'plan_data_volume' => (float)($params['iijmio']['plan_data_volume'] ?? 0),
                 'users' => $users,
             ],
             'alert' => [

--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -212,8 +212,31 @@ final class IijmioUsage
         $totalRemainingDataVolume = array_sum($remainingDataVolume);
         $estimateUsage = $this->__estimateThisMonthUsage($monthlyUsages);
 
+        $planDataVolume = 0.0;
+        if (isset($this->iijmioConfig->plan_data_volume)) {
+            $planDataVolume = (float)$this->iijmioConfig->plan_data_volume;
+        }
+
+        // Sum individual user plan data volumes if configured
+        $hasIndividualVolume = false;
+        $sumIndividualVolume = 0.0;
+        if (isset($this->iijmioConfig->users)) {
+            foreach ($this->iijmioConfig->users as $user => $userInfo) {
+                if (is_object($userInfo) && isset($userInfo->plan_data_volume)) {
+                    $hasIndividualVolume = true;
+                    $sumIndividualVolume += (float)$userInfo->plan_data_volume;
+                } elseif (is_array($userInfo) && isset($userInfo['plan_data_volume'])) {
+                    $hasIndividualVolume = true;
+                    $sumIndividualVolume += (float)$userInfo['plan_data_volume'];
+                }
+            }
+        }
+        if ($hasIndividualVolume) {
+            $planDataVolume = $sumIndividualVolume;
+        }
+
         $isSend = false;
-        if ($estimateUsage > $this->iijmioConfig->plan_data_volume * 0.9) {
+        if ($planDataVolume > 0 && $estimateUsage > $planDataVolume * 0.9) {
             $isSend = true;
             $subject = "[WARN] Mobile usage is not good";
         } else {
@@ -228,14 +251,25 @@ final class IijmioUsage
         foreach ($monthlyUsages as $user => $monthlyUsage) {
             $monthlyUsage = sprintf("%.1f", $monthlyUsage);
             $dailyUsage = sprintf("%.1f", $dailyUsages[$user]);
-            $thisMonthUsageList[] = "  {$this->iijmioConfig->users->$user}: {$monthlyUsage}GB  (+{$dailyUsage})";
+            $userName = $user;
+            if (isset($this->iijmioConfig->users->$user)) {
+                $userInfo = $this->iijmioConfig->users->$user;
+                if (is_object($userInfo) && isset($userInfo->name)) {
+                    $userName = $userInfo->name;
+                } elseif (is_array($userInfo) && isset($userInfo['name'])) {
+                    $userName = $userInfo['name'];
+                } elseif (is_string($userInfo)) {
+                    $userName = $userInfo;
+                }
+            }
+            $thisMonthUsageList[] = "  {$userName}: {$monthlyUsage}GB  (+{$dailyUsage})";
         }
         $thisMonthUsageList = implode("\n", $thisMonthUsageList);
         $thisMonthTotalUsage = sprintf("%.1f", array_sum($monthlyUsages));
         $dailyTotalUsage = sprintf("%.1f", array_sum($dailyUsages));
-        $thisMonthTotalUsageRate = round($thisMonthTotalUsage / $this->iijmioConfig->plan_data_volume * 100, 0);
-        $estimateUsageRate = round($estimateUsage / $this->iijmioConfig->plan_data_volume * 100, 0);
-        $planDataVolume = sprintf("%.1f", $this->iijmioConfig->plan_data_volume);
+        $thisMonthTotalUsageRate = $planDataVolume > 0 ? (int)round($thisMonthTotalUsage / $planDataVolume * 100, 0) : 0;
+        $estimateUsageRate = $planDataVolume > 0 ? (int)round($estimateUsage / $planDataVolume * 100, 0) : 0;
+        $planDataVolumeStr = sprintf("%.1f", $planDataVolume);
         $totalRemainingDataVolume = sprintf("%.1f", $totalRemainingDataVolume);
 
         $message = <<<EOT
@@ -246,7 +280,7 @@ Usage:
   TOTAL: {$thisMonthTotalUsage}GB  (+{$dailyTotalUsage}, {$thisMonthTotalUsageRate}%)
 
 EoM: {$estimateUsage}GB  ({$estimateUsageRate}%)
-Plan: {$planDataVolume}GB
+Plan: {$planDataVolumeStr}GB
 Left: {$totalRemainingDataVolume}GB
 EOT;
 

--- a/tests/config.json.test
+++ b/tests/config.json.test
@@ -3,10 +3,15 @@
         "mio_id": "MA1234567",
         "password": "password",
         "users": {
-            "hdo12345678": "user1",
-            "hdo22345678": "user2"
-        },
-        "plan_data_volume": 6
+            "hdo12345678": {
+                "name": "user1",
+                "plan_data_volume": 4.0
+            },
+            "hdo22345678": {
+                "name": "user2",
+                "plan_data_volume": 2.0
+            }
+        }
     },
     "alert": {
         "bot": "v_bot",

--- a/views/config.blade.php
+++ b/views/config.blade.php
@@ -57,10 +57,6 @@
                     <label for="password">Password:</label>
                     <input type="password" id="password" name="iijmio[password]" value="{{ $config['iijmio']['password'] ?? '' }}" required>
                 </div>
-                <div class="field">
-                    <label for="plan_data_volume">Plan Data Volume (GB):</label>
-                    <input type="number" step="0.1" id="plan_data_volume" name="iijmio[plan_data_volume]" value="{{ $config['iijmio']['plan_data_volume'] ?? '' }}" required>
-                </div>
 
                 <h3>Users</h3>
                 <div class="table-container">
@@ -69,16 +65,22 @@
                             <tr>
                                 <th>HDO Code (e.g. hdo12345678)</th>
                                 <th>Name</th>
+                                <th>Plan Data Volume (GB)</th>
                                 <th>Action</th>
                             </tr>
                         </thead>
                         <tbody id="users-body">
                         @php $userIndex = 0; @endphp
                         @if(isset($config['iijmio']['users']) && is_array($config['iijmio']['users']))
-                            @foreach($config['iijmio']['users'] as $code => $name)
+                            @foreach($config['iijmio']['users'] as $code => $user)
+                            @php
+                                $name = is_array($user) ? ($user['name'] ?? '') : (is_object($user) ? ($user->name ?? '') : $user);
+                                $vol = is_array($user) ? ($user['plan_data_volume'] ?? '') : (is_object($user) ? ($user->plan_data_volume ?? '') : '');
+                            @endphp
                             <tr>
                                 <td><input type="text" name="iijmio[users][{{ $userIndex }}][code]" value="{{ $code }}" required></td>
                                 <td><input type="text" name="iijmio[users][{{ $userIndex }}][name]" value="{{ $name }}" required></td>
+                                <td><input type="number" step="0.1" name="iijmio[users][{{ $userIndex }}][plan_data_volume]" value="{{ $vol }}" required></td>
                                 <td><button type="button" class="btn-remove" onclick="removeRow(this)">Remove</button></td>
                             </tr>
                             @php $userIndex++; @endphp
@@ -122,6 +124,7 @@
             tr.innerHTML = `
                 <td><input type="text" name="iijmio[users][${userIndex}][code]" value="" required placeholder="hdo12345678"></td>
                 <td><input type="text" name="iijmio[users][${userIndex}][name]" value="" required placeholder="Name"></td>
+                <td><input type="number" step="0.1" name="iijmio[users][${userIndex}][plan_data_volume]" value="" required placeholder="4.0"></td>
                 <td><button type="button" class="btn-remove" onclick="removeRow(this)">Remove</button></td>
             `;
             tbody.appendChild(tr);


### PR DESCRIPTION
データ容量の設定を全体の合計値ではなく個人ごとに入力できるように変更しました。

主な変更点：
1. views/config.blade.php
- 全体の「Plan Data Volume」項目を削除
- ユーザーテーブルに「Plan Data Volume (GB)」列を追加し、行追加時のJavaScriptにも反映

2. index.php
- HTTP POSTでの保存処理時に、各ユーザーごとのplan_data_volumeをキャストしてFirestoreに保存するよう変更
- ルートレベルの plan_data_volume フィールドを削除

3. src/IijmioUsage.php
- IIJmioの利用量計算において、各ユーザーごとの plan_data_volume を合計し、それをチェックでの全体の合計値として利用するよう変更（従来の文字列名などの下位互換も担保）

4. テスト・静的解析
- tests/config.json.test を新しい構造に更新し、PHPUnitテストおよびPHPStan解析が問題なくパスすることを確認しました。

5. テンプレート同期
- _template から HOW_TO_INIT.md と README.md を同期しました。


Fixes #28

---
*PR created automatically by Jules for task [8962965532365206448](https://jules.google.com/task/8962965532365206448) started by @yananob*