### PR TITLE
設定画面にプレビュー表示機能を追加

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,40 +1,37 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Run test
 
-# env:
-#   target: iijmio-usage
-
 on:
-  pull_request:
-    branches: test
-    types: [opened, reopened, synchronize]
-    # paths:
-    #   - 'iijmio-usage/**'
-    #   - '.github/workflows/test-iijmio-usage.yml'
-  push:
-    # branches: main
-    # paths:
-    #   - 'iijmio-usage/**'
-    #   - '.github/workflows/test-iijmio-usage.yml'
-  schedule:
-    - cron:  '20 21 * * 5'
+  # pull_request:
+  #   types: [opened, reopened, edited, synchronize]
+  #   branches-ignore:
+  #     - main
+  # push:
+  #   branches:
+  #     - test
+  # schedule:
+  #   - cron:  '45 21 * * 5'
   workflow_dispatch:
+
+concurrency:
+  group: XXX-run-test
+  cancel-in-progress: true
 
 defaults:
   run:
     working-directory: .
 
 permissions:
-  contents: read
+  contents: 'read'
+  id-token: 'write'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    env:
+      GRPC_VERBOSITY: ERROR  # GRPCのログ出力を抑止
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'true'
 
@@ -60,14 +57,27 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-php-
 
-    - name: Install dependencies
+    # - name: Cache NPM packages
+    #   id: npm-cache
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ steps.current_dir.outputs.CURRENT_DIR }}/node_modules
+    #     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-npm-
+
+    - name: Install dependencies (Composer)
       run: composer install --prefer-dist --no-progress
 
-    # - name: Create config.json
-    #   run: |
-    #     pwd
-    #     cp -v configs/config.json.sample configs/config.json
+    # - name: Install dependencies (NPM)
+    #   run: npm install --prefer-offline --no-audit --progress=false
+
+    - name: Google Cloud認証
+      id: 'auth'
+      uses: 'google-github-actions/auth@v3'
+      with:
+        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+        service_account: 'cloud-run-functions-deployer@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
 
     - name: Test with phpunit
-      run: |
-        bash tests/run_tests.sh
+      run: bash tests/run_tests.sh

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,24 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Pull all",
+            "type": "shell",
+            "command": "git pull --all --rebase"
+        },
+        {
+            "label": "run_linter",
+            "type": "shell",
+            "command": "./tests/run_linter.sh"
+        },
+        {
             "label": "run_tests",
             "type": "shell",
             "command": "./tests/run_tests.sh"
+        },
+        {
+            "label": "listen_local_http",
+            "type": "shell",
+            "command": "./tests/listen_local_http.sh"
         },
         {
             "label": "listen_local_event",
@@ -14,9 +29,9 @@
             "command": "./tests/listen_local_event.sh"
         },
         {
-            "label": "deploy",
+            "label": "merge and deploy main",
             "type": "shell",
-            "command": "./deploy.sh"
+            "command": "miscs/merge_and_deploy_main.sh"
         }
     ]
 }

--- a/index.php
+++ b/index.php
@@ -19,6 +19,7 @@ function main_http(ServerRequestInterface $request): string
     $collectionName = AppConfig::getCollectionName();
     $docRef = $firestore->collection($collectionName)->document('config');
     $message = null;
+    $previewMessage = null;
 
     if ($request->getMethod() === 'POST') {
         $params = $request->getParsedBody();
@@ -48,12 +49,28 @@ function main_http(ServerRequestInterface $request): string
             ],
         ];
 
-        $docRef->set($configData);
-        $message = "Config updated successfully.";
+        $action = $params['action'] ?? 'save';
+        if ($action === 'save') {
+            $docRef->set($configData);
+            $message = "Config updated successfully.";
+        } elseif ($action === 'preview') {
+            $configObj = (object)json_decode(json_encode($configData));
+            $logger = new Logger("preview");
+            $iijmio = new IijmioUsage(
+                $configObj->iijmio,
+                $configObj->alert->send_usage_each_n_days,
+                $logger
+            );
+            try {
+                [, $previewMessage] = $iijmio->getStats();
+            } catch (\Exception $e) {
+                $previewMessage = "Error: " . $e->getMessage();
+            }
+        }
+    } else {
+        $doc = $docRef->snapshot();
+        $configData = $doc->exists() ? $doc->data() : [];
     }
-
-    $doc = $docRef->snapshot();
-    $configData = $doc->exists() ? $doc->data() : [];
 
     $views = __DIR__ . '/views';
     $cache = '/tmp/cache';
@@ -64,6 +81,7 @@ function main_http(ServerRequestInterface $request): string
 
     return $blade->run("config", [
         "message" => $message,
+        "previewMessage" => $previewMessage ?? null,
         "collectionName" => $collectionName,
         "config" => $configData,
         "appEnv" => getenv('APP_ENV') ?: 'unknown',

--- a/views/config.blade.php
+++ b/views/config.blade.php
@@ -25,9 +25,15 @@
         .btn-add:hover { background-color: #0277bd; }
         .btn-save { background-color: #43a047; color: white; font-size: 1.1em; display: block; width: 100%; }
         .btn-save:hover { background-color: #388e3c; }
+        .btn-preview { background-color: #0288d1; color: white; font-size: 1.1em; display: block; width: 100%; }
+        .btn-preview:hover { background-color: #0277bd; }
         .btn-remove { background-color: #e53935; color: white; padding: 6px 12px; }
         .btn-remove:hover { background-color: #d32f2f; }
         .env-info { background: #eee; padding: 0.2em 0.5em; border-radius: 4px; font-family: monospace; display: inline-block; word-break: break-all; }
+        .preview-section { background-color: #e1f5fe; border: 1px solid #b3e5fc; padding: 1em; border-radius: 4px; margin-bottom: 2em; }
+        .preview-title { color: #01579b; margin-top: 0; font-size: 1.2em; border-bottom: 2px solid #b3e5fc; padding-bottom: 0.5em; }
+        .preview-content { white-space: pre-wrap; word-break: break-all; background: #f1f8ff; padding: 1em; border-radius: 4px; border: 1px solid #b3e5fc; font-family: monospace; font-size: 1em; margin: 0; }
+        .button-group { display: flex; gap: 10px; margin-top: 1em; }
 
         @media (max-width: 600px) {
             body { padding: 0.5em; }
@@ -42,6 +48,13 @@
         <h1>IIJmio Usage Checker Config</h1>
         @if($message)
             <div class="message">{{ $message }}</div>
+        @endif
+
+        @if($previewMessage)
+            <section class="preview-section">
+                <h2 class="preview-title">Preview Result</h2>
+                <pre class="preview-content">{{ $previewMessage }}</pre>
+            </section>
         @endif
 
         <p>Firestore Collection: <span class="env-info">{{ $collectionName }}</span></p>
@@ -122,7 +135,10 @@
                 </div>
             </section>
 
-            <button type="submit" class="btn-save">Save Config</button>
+            <div class="button-group">
+                <button type="submit" name="action" value="preview" class="btn-preview">Preview</button>
+                <button type="submit" name="action" value="save" class="btn-save">Save Config</button>
+            </div>
         </form>
 
         <div class="footer">


### PR DESCRIPTION
設定画面（Web GUI）から、現在の入力内容を使用してIIJmioのデータ使用状況をプレビューできる機能を追加しました。
- index.php: POSTリクエスト時に「Preview」アクションを判別し、Firestoreへの上書き保存をスキップした上で一時入力データから getStats() を呼び出し、結果メッセージ（またはエラーメッセージ）を取得するよう修正しました。
- views/config.blade.php:
  - 「Preview」と「Save Config」ボタンをフレックスボックスの横並びレイアウトで配置しました。
  - プレビュー結果が表示される際、等幅フォントかつ改行を保持する視認性の高いプレビュー表示ブロック（青ベース）をレイアウト上部に追加しました。
- _template: 各種設定テンプレートの最新変更（タスク定義、ワークフロー、イシューテンプレート等）をマージ・反映しました。
- 検証: phpunit、phpstan、および Playwright を用いたモック描画画面のスクリーンショットによる表示チェックを行い、すべて完全に動作することを確認しました。

Fixes #34

---
*PR created automatically by Jules for task [9340954005565790962](https://jules.google.com/task/9340954005565790962) started by @yananob*