### PR TITLE
月末予測値の改善

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,6 +9,8 @@ use App\Utils\Line;
 use App\IijmioUsage;
 use App\AppConfig;
 use App\Firestore;
+use App\Consts;
+use Carbon\Carbon;
 use Psr\Http\Message\ServerRequestInterface;
 use eftec\bladeone\BladeOne;
 
@@ -56,10 +58,14 @@ function main_http(ServerRequestInterface $request): string
         } elseif ($action === 'preview') {
             $configObj = (object)json_decode(json_encode($configData));
             $logger = new Logger("preview");
+            $historyDoc = $firestore->collection($collectionName)->document('history')->snapshot();
+            $history = $historyDoc->exists() ? $historyDoc->data() : [];
+
             $iijmio = new IijmioUsage(
                 $configObj->iijmio,
                 $configObj->alert->send_usage_each_n_days,
-                $logger
+                $logger,
+                $history
             );
             try {
                 [, $previewMessage] = $iijmio->getStats();
@@ -107,12 +113,25 @@ function main_event(CloudEventInterface $event): void
 
     $config = (object)json_decode(json_encode($doc->data()));
 
+    $historyDoc = $firestore->collection($collectionName)->document('history')->snapshot();
+    $history = $historyDoc->exists() ? $historyDoc->data() : [];
+
     $iijmio = new IijmioUsage(
         $config->iijmio,
         $config->alert->send_usage_each_n_days,
-        $logger
+        $logger,
+        $history
     );
-    [$isSendAlert, $message] = $iijmio->getStats();
+    [$isSendAlert, $message, $monthlyUsages] = $iijmio->getStats();
+
+    if (!empty($monthlyUsages)) {
+        $today = (new Carbon(timezone: Consts::TIMEZONE))->format('Y-m-d');
+        $firestore->collection($collectionName)->document('history')->set([
+            $today => $monthlyUsages
+        ], ['merge' => true]);
+        $logger->log("Saved daily usage history for {$today}.");
+    }
+
     if ($isSendAlert) {
         $lineTokensAndTargets = json_decode(getenv('LINE_TOKENS_N_TARGETS'), false);
         $botName = $config->alert->bot ?? null;

--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -12,7 +12,8 @@ final class IijmioUsage
     public function __construct(
         private object $iijmioConfig,
         private int $sendEachNDays = 10,
-        private ?Logger $logger = null
+        private ?Logger $logger = null,
+        private array $history = []
     ) {
     }
 
@@ -21,7 +22,8 @@ final class IijmioUsage
         $this->logger?->info("Starting to crawl IIJmio usage data...");
         [$remainingDataVolume, $monthlyUsages, $dailyUsages] = $this->__crawl();
         $this->logger?->info("Successfully crawled data.");
-        return $this->__judgeResult($remainingDataVolume, $monthlyUsages, $dailyUsages);
+        [$isSend, $message] = $this->__judgeResult($remainingDataVolume, $monthlyUsages, $dailyUsages);
+        return [$isSend, $message, $monthlyUsages];
     }
 
     private function __crawl(): array
@@ -278,7 +280,53 @@ EOT;
     private function __estimateThisMonthUsage(array $monthlyUsage): float
     {
         $now = new Carbon(timezone: Consts::TIMEZONE);
-        return round(array_sum($monthlyUsage) * $now->daysInMonth() / $now->day, 1);
+        $todayStr = $now->format('Y-m-d');
+        $currentYearMonth = $now->format('Y-m');
+        $daysInMonth = $now->daysInMonth();
+        $currentDay = $now->day;
+
+        $monthlyHistory = [];
+        foreach ($this->history as $dateStr => $usages) {
+            if (str_starts_with($dateStr, $currentYearMonth) && $dateStr < $todayStr) {
+                $monthlyHistory[$dateStr] = $usages;
+            }
+        }
+        krsort($monthlyHistory);
+
+        $totalEstimated = 0.0;
+        foreach ($monthlyUsage as $user => $currentUsage) {
+            $estimatedUserUsage = null;
+            foreach ($monthlyHistory as $dateStr => $usages) {
+                $userPastUsage = null;
+                if (is_object($usages) && isset($usages->$user)) {
+                    $userPastUsage = (float)$usages->$user;
+                } elseif (is_array($usages) && isset($usages[$user])) {
+                    $userPastUsage = (float)$usages[$user];
+                }
+
+                if ($userPastUsage !== null) {
+                    $pastCarbon = new Carbon($dateStr, timezone: Consts::TIMEZONE);
+                    $dayDiff = $currentDay - $pastCarbon->day;
+                    if ($dayDiff >= 1) {
+                        $consumption = $currentUsage - $userPastUsage;
+                        $avgConsumptionPerDay = max(0.0, $consumption / $dayDiff);
+                        $remainingDays = $daysInMonth - $currentDay;
+                        $estimatedUserUsage = $currentUsage + ($avgConsumptionPerDay * $remainingDays);
+                        $this->logger?->info("User {$user}: estimated using history of {$dateStr}. Past: {$userPastUsage}GB, Current: {$currentUsage}GB, Diff days: {$dayDiff}, Avg/Day: {$avgConsumptionPerDay}GB. Estimate: {$estimatedUserUsage}GB");
+                        break;
+                    }
+                }
+            }
+
+            if ($estimatedUserUsage === null) {
+                $estimatedUserUsage = ($currentUsage / $currentDay) * $daysInMonth;
+                $this->logger?->info("User {$user}: no history found. Estimate using simple proportion: {$estimatedUserUsage}GB");
+            }
+
+            $totalEstimated += $estimatedUserUsage;
+        }
+
+        return round($totalEstimated, 1);
     }
 
 }

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -137,4 +137,57 @@ EOT;
         $this->assertSame(9.9, $result);
     }
 
+    public function testEstimateThisMonthUsageWithHistory(): void
+    {
+        Carbon::setTestNow(new Carbon('2024-11-10 12:00:00', timezone: Consts::TIMEZONE));
+
+        $history = [
+            "2024-11-06" => [
+                "hdo12345678" => 0.7,
+                "hdo22345678" => 1.8
+            ],
+            "2024-10-31" => [
+                "hdo12345678" => 0.5,
+                "hdo22345678" => 1.5
+            ]
+        ];
+
+        $iijmio = new IijmioUsage(
+            iijmioConfig: $this->config->iijmio,
+            history: $history
+        );
+
+        $result = Test::invokePrivateMethod(
+            $iijmio,
+            "__estimateThisMonthUsage",
+            ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
+        );
+
+        $this->assertSame(7.3, $result);
+    }
+
+    public function testEstimateThisMonthUsageWithNegativeConsumptionHistory(): void
+    {
+        Carbon::setTestNow(new Carbon('2024-11-10 12:00:00', timezone: Consts::TIMEZONE));
+
+        $history = [
+            "2024-11-06" => [
+                "hdo12345678" => 1.5,
+            ]
+        ];
+
+        $iijmio = new IijmioUsage(
+            iijmioConfig: $this->config->iijmio,
+            history: $history
+        );
+
+        $result = Test::invokePrivateMethod(
+            $iijmio,
+            "__estimateThisMonthUsage",
+            ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
+        );
+
+        $this->assertSame(7.7, $result);
+    }
+
 }


### PR DESCRIPTION
月中のデータ利用実績（日々の累積値）をFirestoreに履歴として蓄積し、直近の使用ペースに基づいた高精度な月末予測値を算出するアルゴリズムを実装しました。また、テンプレートから `.github/ISSUE_TEMPLATE/default.md` を最新の内容に更新しました。

Fixes #37

---
*PR created automatically by Jules for task [3794593012929194846](https://jules.google.com/task/3794593012929194846) started by @yananob*