### PR TITLE
予測詳細の出力機能の追加

### DIFF
--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -212,7 +212,7 @@ final class IijmioUsage
     private function __judgeResult(array $remainingDataVolume, array $monthlyUsages, array $dailyUsages): array
     {
         $totalRemainingDataVolume = array_sum($remainingDataVolume);
-        $estimateUsage = $this->__estimateThisMonthUsage($monthlyUsages);
+        [$estimateUsage, $estimateDetails] = $this->__estimateThisMonthUsage($monthlyUsages);
 
         $planDataVolume = 0.0;
         if (isset($this->iijmioConfig->users)) {
@@ -262,6 +262,38 @@ final class IijmioUsage
         $planDataVolumeStr = sprintf("%.1f", $planDataVolume);
         $totalRemainingDataVolume = sprintf("%.1f", $totalRemainingDataVolume);
 
+        $detailList = [];
+        foreach ($estimateDetails as $user => $detail) {
+            $userName = $user;
+            if (isset($this->iijmioConfig->users->$user)) {
+                $userInfo = $this->iijmioConfig->users->$user;
+                if (is_object($userInfo) && isset($userInfo->name)) {
+                    $userName = $userInfo->name;
+                } elseif (is_array($userInfo) && isset($userInfo['name'])) {
+                    $userName = $userInfo['name'];
+                } elseif (is_string($userInfo)) {
+                    $userName = $userInfo;
+                }
+            }
+
+            if ($detail['type'] === 'history') {
+                $pastDate = $detail['pastDate'];
+                $pastUsageStr = sprintf("%.1f", $detail['pastUsage']);
+                $dayDiff = $detail['dayDiff'];
+                $consumptionStr = sprintf("%+.1f", $detail['consumption']);
+                $avgStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
+                $remainingDays = $detail['remainingDays'];
+                $detailList[] = "  {$userName}: {$pastDate}({$pastUsageStr}GB)から{$dayDiff}日間で{$consumptionStr}GB(日平均{$avgStr}GB)。残り{$remainingDays}日予測。";
+            } else {
+                $currentDay = $detail['currentDay'];
+                $currentUsageStr = sprintf("%.1f", $detail['currentUsage']);
+                $avgStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
+                $remainingDays = $detail['remainingDays'];
+                $detailList[] = "  {$userName}: 履歴なし。{$currentDay}日間で{$currentUsageStr}GB(日平均{$avgStr}GB)。残り{$remainingDays}日予測。";
+            }
+        }
+        $detailStr = implode("\n", $detailList);
+
         $message = <<<EOT
 {$subject}
 
@@ -272,12 +304,15 @@ Usage:
 EoM: {$estimateUsage}GB  ({$estimateUsageRate}%)
 Plan: {$planDataVolumeStr}GB
 Left: {$totalRemainingDataVolume}GB
+
+[予測根拠]
+{$detailStr}
 EOT;
 
         return [$isSend, $message];
     }
 
-    private function __estimateThisMonthUsage(array $monthlyUsage): float
+    private function __estimateThisMonthUsage(array $monthlyUsage): array
     {
         $now = new Carbon(timezone: Consts::TIMEZONE);
         $todayStr = $now->format('Y-m-d');
@@ -294,8 +329,10 @@ EOT;
         krsort($monthlyHistory);
 
         $totalEstimated = 0.0;
+        $details = [];
         foreach ($monthlyUsage as $user => $currentUsage) {
             $estimatedUserUsage = null;
+            $detail = [];
             foreach ($monthlyHistory as $dateStr => $usages) {
                 $userPastUsage = null;
                 if (is_object($usages) && isset($usages->$user)) {
@@ -313,6 +350,17 @@ EOT;
                         $remainingDays = $daysInMonth - $currentDay;
                         $estimatedUserUsage = $currentUsage + ($avgConsumptionPerDay * $remainingDays);
                         $this->logger?->info("User {$user}: estimated using history of {$dateStr}. Past: {$userPastUsage}GB, Current: {$currentUsage}GB, Diff days: {$dayDiff}, Avg/Day: {$avgConsumptionPerDay}GB. Estimate: {$estimatedUserUsage}GB");
+
+                        $detail = [
+                            'type' => 'history',
+                            'pastDate' => $pastCarbon->format('m/d'),
+                            'pastUsage' => $userPastUsage,
+                            'currentUsage' => $currentUsage,
+                            'dayDiff' => $dayDiff,
+                            'consumption' => round($consumption, 2),
+                            'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
+                            'remainingDays' => $remainingDays,
+                        ];
                         break;
                     }
                 }
@@ -321,12 +369,23 @@ EOT;
             if ($estimatedUserUsage === null) {
                 $estimatedUserUsage = ($currentUsage / $currentDay) * $daysInMonth;
                 $this->logger?->info("User {$user}: no history found. Estimate using simple proportion: {$estimatedUserUsage}GB");
+                $avgConsumptionPerDay = $currentUsage / $currentDay;
+                $remainingDays = $daysInMonth - $currentDay;
+
+                $detail = [
+                    'type' => 'simple',
+                    'currentDay' => $currentDay,
+                    'currentUsage' => $currentUsage,
+                    'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
+                    'remainingDays' => $remainingDays,
+                ];
             }
 
             $totalEstimated += $estimatedUserUsage;
+            $details[$user] = $detail;
         }
 
-        return round($totalEstimated, 1);
+        return [round($totalEstimated, 1), $details];
     }
 
 }

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -81,6 +81,10 @@ Usage:
 EoM: 5.2GB  (87%)
 Plan: 6.0GB
 Left: 6.5GB
+
+[予測根拠]
+  user1: 履歴なし。11日間で0.9GB(日平均0.08GB)。残り19日予測。
+  user2: 履歴なし。11日間で1.0GB(日平均0.09GB)。残り19日予測。
 EOT;
         $this->assertEquals($expectedMessage, $message);
 
@@ -94,6 +98,7 @@ EOT;
             ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
         );
         $this->assertTrue($isSendAlert);
+        $this->assertStringContainsString("[予測根拠]\n  user1: 履歴なし。20日間で0.9GB(日平均0.04GB)。残り10日予測。\n  user2: 履歴なし。20日間で1.0GB(日平均0.05GB)。残り10日予測。", $message);
 
         // アラートあり（使用量同じだが、日付がまだ月初に近い）
         Carbon::setTestNow(new Carbon('2024-11-09 12:00:00', timezone: Consts::TIMEZONE));
@@ -117,6 +122,10 @@ Usage:
 EoM: 6.3GB  (105%)
 Plan: 6.0GB
 Left: 6.5GB
+
+[予測根拠]
+  user1: 履歴なし。9日間で0.9GB(日平均0.10GB)。残り21日予測。
+  user2: 履歴なし。9日間で1.0GB(日平均0.11GB)。残り21日予測。
 EOT;
         $this->assertEquals($expectedMessage, $message);
     }
@@ -126,15 +135,19 @@ EOT;
         Carbon::setTestNow(new Carbon('2024-11-10 12:00:00', timezone: Consts::TIMEZONE));
 
         $iijmio = new IijmioUsage(iijmioConfig: $this->config->iijmio);
-        $result = Test::invokePrivateMethod(
+        [$result, $details] = Test::invokePrivateMethod(
             $iijmio,
             "__estimateThisMonthUsage",
-            ["hdo12345678" => 1.1, "hdo22345678" => 2.2],
-            ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
+            ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
         );
 
-        $this->assertNotEmpty($result);
         $this->assertSame(9.9, $result);
+        $this->assertCount(2, $details);
+        $this->assertSame('simple', $details['hdo12345678']['type']);
+        $this->assertSame(10, $details['hdo12345678']['currentDay']);
+        $this->assertSame(1.1, $details['hdo12345678']['currentUsage']);
+        $this->assertSame(0.11, $details['hdo12345678']['avgConsumptionPerDay']);
+        $this->assertSame(20, $details['hdo12345678']['remainingDays']);
     }
 
     public function testEstimateThisMonthUsageWithHistory(): void
@@ -157,13 +170,20 @@ EOT;
             history: $history
         );
 
-        $result = Test::invokePrivateMethod(
+        [$result, $details] = Test::invokePrivateMethod(
             $iijmio,
             "__estimateThisMonthUsage",
             ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
         );
 
         $this->assertSame(7.3, $result);
+        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame('11/06', $details['hdo12345678']['pastDate']);
+        $this->assertSame(0.7, $details['hdo12345678']['pastUsage']);
+        $this->assertSame(4, $details['hdo12345678']['dayDiff']);
+        $this->assertSame(0.4, $details['hdo12345678']['consumption']);
+        $this->assertSame(0.1, $details['hdo12345678']['avgConsumptionPerDay']);
+        $this->assertSame(20, $details['hdo12345678']['remainingDays']);
     }
 
     public function testEstimateThisMonthUsageWithNegativeConsumptionHistory(): void
@@ -181,13 +201,16 @@ EOT;
             history: $history
         );
 
-        $result = Test::invokePrivateMethod(
+        [$result, $details] = Test::invokePrivateMethod(
             $iijmio,
             "__estimateThisMonthUsage",
             ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
         );
 
         $this->assertSame(7.7, $result);
+        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame(-0.4, $details['hdo12345678']['consumption']);
+        $this->assertSame(0.0, $details['hdo12345678']['avgConsumptionPerDay']);
     }
 
 }


### PR DESCRIPTION
予測値の根拠となる情報（履歴利用の日平均消費量、または履歴なしの単純比例計算）を生成メッセージの末尾に出力する機能を追加しました。テストケースを拡充し、正常にテストおよび静的解析がパスすることを確認しました。

Fixes #40

---
*PR created automatically by Jules for task [11347247406816529548](https://jules.google.com/task/11347247406816529548) started by @yananob*