### PR TITLE
予測根拠の改善と月末予測値の追加

### DIFF
--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -262,6 +262,8 @@ final class IijmioUsage
         $planDataVolumeStr = sprintf("%.1f", $planDataVolume);
         $totalRemainingDataVolume = sprintf("%.1f", $totalRemainingDataVolume);
 
+        $remainingDays = $now->daysInMonth() - $now->day;
+
         $detailList = [];
         foreach ($estimateDetails as $user => $detail) {
             $userName = $user;
@@ -276,20 +278,20 @@ final class IijmioUsage
                 }
             }
 
+            $estimatedUserUsageStr = sprintf("%.1f", $detail['estimatedUserUsage']);
+
             if ($detail['type'] === 'history') {
                 $pastDate = $detail['pastDate'];
                 $pastUsageStr = sprintf("%.1f", $detail['pastUsage']);
                 $dayDiff = $detail['dayDiff'];
                 $consumptionStr = sprintf("%+.1f", $detail['consumption']);
                 $avgStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
-                $remainingDays = $detail['remainingDays'];
-                $detailList[] = "  {$userName}: {$pastDate}({$pastUsageStr}GB)から{$dayDiff}日間で{$consumptionStr}GB(日平均{$avgStr}GB)。残り{$remainingDays}日予測。";
+                $detailList[] = "  {$userName}: {$pastDate}({$pastUsageStr}GB)から{$dayDiff}日間で{$consumptionStr}GB(日平均{$avgStr}GB) -> 月末予測: {$estimatedUserUsageStr}GB";
             } else {
                 $currentDay = $detail['currentDay'];
                 $currentUsageStr = sprintf("%.1f", $detail['currentUsage']);
                 $avgStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
-                $remainingDays = $detail['remainingDays'];
-                $detailList[] = "  {$userName}: 履歴なし。{$currentDay}日間で{$currentUsageStr}GB(日平均{$avgStr}GB)。残り{$remainingDays}日予測。";
+                $detailList[] = "  {$userName}: 履歴なし。{$currentDay}日間で{$currentUsageStr}GB(日平均{$avgStr}GB) -> 月末予測: {$estimatedUserUsageStr}GB";
             }
         }
         $detailStr = implode("\n", $detailList);
@@ -305,7 +307,7 @@ EoM: {$estimateUsage}GB  ({$estimateUsageRate}%)
 Plan: {$planDataVolumeStr}GB
 Left: {$totalRemainingDataVolume}GB
 
-[予測根拠]
+[予測根拠] (残り{$remainingDays}日)
 {$detailStr}
 EOT;
 
@@ -360,6 +362,7 @@ EOT;
                             'consumption' => round($consumption, 2),
                             'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
                             'remainingDays' => $remainingDays,
+                            'estimatedUserUsage' => $estimatedUserUsage,
                         ];
                         break;
                     }
@@ -378,6 +381,7 @@ EOT;
                     'currentUsage' => $currentUsage,
                     'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
                     'remainingDays' => $remainingDays,
+                    'estimatedUserUsage' => $estimatedUserUsage,
                 ];
             }
 

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -82,9 +82,9 @@ EoM: 5.2GB  (87%)
 Plan: 6.0GB
 Left: 6.5GB
 
-[予測根拠]
-  user1: 履歴なし。11日間で0.9GB(日平均0.08GB)。残り19日予測。
-  user2: 履歴なし。11日間で1.0GB(日平均0.09GB)。残り19日予測。
+[予測根拠] (残り19日)
+  user1: 履歴なし。11日間で0.9GB(日平均0.08GB) -> 月末予測: 2.5GB
+  user2: 履歴なし。11日間で1.0GB(日平均0.09GB) -> 月末予測: 2.7GB
 EOT;
         $this->assertEquals($expectedMessage, $message);
 
@@ -98,7 +98,7 @@ EOT;
             ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
         );
         $this->assertTrue($isSendAlert);
-        $this->assertStringContainsString("[予測根拠]\n  user1: 履歴なし。20日間で0.9GB(日平均0.04GB)。残り10日予測。\n  user2: 履歴なし。20日間で1.0GB(日平均0.05GB)。残り10日予測。", $message);
+        $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 履歴なし。20日間で0.9GB(日平均0.04GB) -> 月末予測: 1.3GB\n  user2: 履歴なし。20日間で1.0GB(日平均0.05GB) -> 月末予測: 1.5GB", $message);
 
         // アラートあり（使用量同じだが、日付がまだ月初に近い）
         Carbon::setTestNow(new Carbon('2024-11-09 12:00:00', timezone: Consts::TIMEZONE));
@@ -123,9 +123,9 @@ EoM: 6.3GB  (105%)
 Plan: 6.0GB
 Left: 6.5GB
 
-[予測根拠]
-  user1: 履歴なし。9日間で0.9GB(日平均0.10GB)。残り21日予測。
-  user2: 履歴なし。9日間で1.0GB(日平均0.11GB)。残り21日予測。
+[予測根拠] (残り21日)
+  user1: 履歴なし。9日間で0.9GB(日平均0.10GB) -> 月末予測: 3.0GB
+  user2: 履歴なし。9日間で1.0GB(日平均0.11GB) -> 月末予測: 3.3GB
 EOT;
         $this->assertEquals($expectedMessage, $message);
     }


### PR DESCRIPTION
予測根拠の内容を改善しました。残り日数は各ユーザーの詳細行ではなく、全体のヘッダー（例: [予測根拠] (残りX日)）に表示するように変更しました。さらに、各ユーザーの予測について、個別詳細の末尾に「-> 月末予測: Y.YGB」として月末の予測値を出力するようにしました。
テストコードも新しいメッセージフォーマットに追従するように修正し、静的解析もすべてパスしています。
また、指示に従い `.github/ISSUE_TEMPLATE/default.md` を最新の `_template` から同期しました。

---
*PR created automatically by Jules for task [10782263403215915387](https://jules.google.com/task/10782263403215915387) started by @yananob*