### PR TITLE
履歴データから約1週間分のデータを使ってデータ使用量を予測するよう改善

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,0 +1,58 @@
+name: Initialize Repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      function_name:
+        description: 'Function name (used for replacement)'
+        required: true
+      template_repo_url:
+        description: 'URL of the template repository for _template submodule'
+        required: true
+        default: 'https://github.com/yananob/_template'
+      common_repo_url:
+        description: 'URL of the common repository for _cf-common submodule'
+        required: true
+        default: 'https://github.com/yananob/cloud-functions-common'
+
+jobs:
+  initialize:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add submodules
+        run: |
+          git submodule add ${{ github.event.inputs.common_repo_url }} _cf-common
+          git submodule add ${{ github.event.inputs.template_repo_url }} _template
+          git commit -m "Add _cf-common and _template submodules"
+
+      - name: Replace placeholders
+        env:
+          FUNCTION_NAME: ${{ github.event.inputs.function_name }}
+        run: |
+          # _cf-common/, _template/, .git/ を除外して一括置換
+          # sed のデリミタに | を使用し、入力値に含まれる / に対応
+          find . -type f -not -path '*/.git/*' -not -path './_cf-common/*' -not -path './_template/*' -exec sed -i "s|{{VALUES_FUNCTION_NAME}}|${FUNCTION_NAME}|g" {} +
+          git add .
+          if ! git diff-index --quiet HEAD; then
+            git commit -m "Initialize project with function name: ${FUNCTION_NAME}"
+          fi
+
+      - name: Self-destruct
+        run: |
+          rm .github/workflows/init.yml
+          git add .github/workflows/init.yml
+          git commit -m "Self-destruct initialization workflow"
+
+      - name: Push changes
+        run: git push origin ${{ github.ref_name }}

--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -333,8 +333,11 @@ EOT;
         $totalEstimated = 0.0;
         $details = [];
         foreach ($monthlyUsage as $user => $currentUsage) {
-            $estimatedUserUsage = null;
-            $detail = [];
+            $bestDateStr = null;
+            $bestUserPastUsage = null;
+            $bestDayDiff = null;
+            $minDistance = null;
+
             foreach ($monthlyHistory as $dateStr => $usages) {
                 $userPastUsage = null;
                 if (is_object($usages) && isset($usages->$user)) {
@@ -347,26 +350,39 @@ EOT;
                     $pastCarbon = new Carbon($dateStr, timezone: Consts::TIMEZONE);
                     $dayDiff = $currentDay - $pastCarbon->day;
                     if ($dayDiff >= 1) {
-                        $consumption = $currentUsage - $userPastUsage;
-                        $avgConsumptionPerDay = max(0.0, $consumption / $dayDiff);
-                        $remainingDays = $daysInMonth - $currentDay;
-                        $estimatedUserUsage = $currentUsage + ($avgConsumptionPerDay * $remainingDays);
-                        $this->logger?->info("User {$user}: estimated using history of {$dateStr}. Past: {$userPastUsage}GB, Current: {$currentUsage}GB, Diff days: {$dayDiff}, Avg/Day: {$avgConsumptionPerDay}GB. Estimate: {$estimatedUserUsage}GB");
-
-                        $detail = [
-                            'type' => 'history',
-                            'pastDate' => $pastCarbon->format('m/d'),
-                            'pastUsage' => $userPastUsage,
-                            'currentUsage' => $currentUsage,
-                            'dayDiff' => $dayDiff,
-                            'consumption' => round($consumption, 2),
-                            'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
-                            'remainingDays' => $remainingDays,
-                            'estimatedUserUsage' => $estimatedUserUsage,
-                        ];
-                        break;
+                        $distance = abs($dayDiff - 7);
+                        if ($minDistance === null || $distance < $minDistance || ($distance === $minDistance && $dayDiff > $bestDayDiff)) {
+                            $minDistance = $distance;
+                            $bestDayDiff = $dayDiff;
+                            $bestDateStr = $dateStr;
+                            $bestUserPastUsage = $userPastUsage;
+                        }
                     }
                 }
+            }
+
+            $estimatedUserUsage = null;
+            $detail = [];
+            if ($bestDateStr !== null && $bestUserPastUsage !== null && $bestDayDiff !== null) {
+                $consumption = $currentUsage - $bestUserPastUsage;
+                $avgConsumptionPerDay = max(0.0, $consumption / $bestDayDiff);
+                $remainingDays = $daysInMonth - $currentDay;
+                $estimatedUserUsage = $currentUsage + ($avgConsumptionPerDay * $remainingDays);
+
+                $pastCarbon = new Carbon($bestDateStr, timezone: Consts::TIMEZONE);
+                $this->logger?->info("User {$user}: estimated using history of {$bestDateStr}. Past: {$bestUserPastUsage}GB, Current: {$currentUsage}GB, Diff days: {$bestDayDiff}, Avg/Day: {$avgConsumptionPerDay}GB. Estimate: {$estimatedUserUsage}GB");
+
+                $detail = [
+                    'type' => 'history',
+                    'pastDate' => $pastCarbon->format('m/d'),
+                    'pastUsage' => $bestUserPastUsage,
+                    'currentUsage' => $currentUsage,
+                    'dayDiff' => $bestDayDiff,
+                    'consumption' => round($consumption, 2),
+                    'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
+                    'remainingDays' => $remainingDays,
+                    'estimatedUserUsage' => $estimatedUserUsage,
+                ];
             }
 
             if ($estimatedUserUsage === null) {

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -213,4 +213,72 @@ EOT;
         $this->assertSame(0.0, $details['hdo12345678']['avgConsumptionPerDay']);
     }
 
+    public function testEstimateThisMonthUsageWithMultipleHistory(): void
+    {
+        // 1. Exact match (7 days ago) should be preferred.
+        Carbon::setTestNow(new Carbon('2024-11-15 12:00:00', timezone: Consts::TIMEZONE));
+
+        $history = [
+            "2024-11-14" => [ // 1 day ago
+                "hdo12345678" => 1.4,
+            ],
+            "2024-11-10" => [ // 5 days ago
+                "hdo12345678" => 1.0,
+            ],
+            "2024-11-08" => [ // 7 days ago (target)
+                "hdo12345678" => 0.8,
+            ],
+            "2024-11-06" => [ // 9 days ago
+                "hdo12345678" => 0.6,
+            ]
+        ];
+
+        $iijmio = new IijmioUsage(
+            iijmioConfig: $this->config->iijmio,
+            history: $history
+        );
+
+        [$result, $details] = Test::invokePrivateMethod(
+            $iijmio,
+            "__estimateThisMonthUsage",
+            ["hdo12345678" => 1.5, "hdo22345678" => 2.0]
+        );
+
+        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame('11/08', $details['hdo12345678']['pastDate']);
+        $this->assertSame(7, $details['hdo12345678']['dayDiff']);
+        $this->assertSame(0.8, $details['hdo12345678']['pastUsage']);
+    }
+
+    public function testEstimateThisMonthUsageWithHistoryTieBreaking(): void
+    {
+        // 2. Tie breaking: 6 days ago vs 8 days ago. 8 days ago has larger dayDiff, so should be chosen.
+        Carbon::setTestNow(new Carbon('2024-11-15 12:00:00', timezone: Consts::TIMEZONE));
+
+        $history = [
+            "2024-11-09" => [ // 6 days ago
+                "hdo12345678" => 0.9,
+            ],
+            "2024-11-07" => [ // 8 days ago (larger dayDiff tie-breaker)
+                "hdo12345678" => 0.7,
+            ]
+        ];
+
+        $iijmio = new IijmioUsage(
+            iijmioConfig: $this->config->iijmio,
+            history: $history
+        );
+
+        [$result, $details] = Test::invokePrivateMethod(
+            $iijmio,
+            "__estimateThisMonthUsage",
+            ["hdo12345678" => 1.5, "hdo22345678" => 2.0]
+        );
+
+        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame('11/07', $details['hdo12345678']['pastDate']);
+        $this->assertSame(8, $details['hdo12345678']['dayDiff']);
+        $this->assertSame(0.7, $details['hdo12345678']['pastUsage']);
+    }
+
 }


### PR DESCRIPTION
IIJmioのデータ使用量予測において、直近1日分の履歴から算出した日平均使用量を用いると日々の変動ノイズを拾いやすいため、1週間（7日）前に最も近い履歴データを優先して日平均を算出し、予測精度を向上させました。テストの追加とテンプレートファイルの同期もあわせて行っています。

---
*PR created automatically by Jules for task [8129812884132263776](https://jules.google.com/task/8129812884132263776) started by @yananob*