### PR TITLE
月末予測ロジックの改善

### DIFF
--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -279,19 +279,30 @@ final class IijmioUsage
             }
 
             $estimatedUserUsageStr = sprintf("%.1f", $detail['estimatedUserUsage']);
+            $rProjectedStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
 
-            if ($detail['type'] === 'history') {
-                $pastDate = $detail['pastDate'];
-                $pastUsageStr = sprintf("%.1f", $detail['pastUsage']);
-                $dayDiff = $detail['dayDiff'];
-                $consumptionStr = sprintf("%+.1f", $detail['consumption']);
-                $avgStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
-                $detailList[] = "  {$userName}: {$pastDate}({$pastUsageStr}GB)から{$dayDiff}日間で{$consumptionStr}GB(日平均{$avgStr}GB) -> 月末予測: {$estimatedUserUsageStr}GB";
+            if ($detail['wCurrent'] < 1.0) {
+                // Beginning of the month (blended with baseline)
+                $rCurrentBlended = $detail['hasRecent']
+                    ? (0.5 * $detail['rRecent'] + 0.5 * $detail['rCumulative'])
+                    : $detail['rCumulative'];
+                $rCurrentBlendedStr = sprintf("%.2f", $rCurrentBlended);
+                $rBaselineStr = sprintf("%.2f", $detail['rBaseline']);
+                $wCurrentPct = (int)round($detail['wCurrent'] * 100);
+                $wBaselinePct = 100 - $wCurrentPct;
+
+                $detailList[] = "  {$userName}: 日平均 {$rProjectedStr}GB [内訳: 今月実績 {$rCurrentBlendedStr}GB×{$wCurrentPct}% + 前月/計画 {$rBaselineStr}GB×{$wBaselinePct}%] -> 月末予測: {$estimatedUserUsageStr}GB";
             } else {
-                $currentDay = $detail['currentDay'];
-                $currentUsageStr = sprintf("%.1f", $detail['currentUsage']);
-                $avgStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
-                $detailList[] = "  {$userName}: 履歴なし。{$currentDay}日間で{$currentUsageStr}GB(日平均{$avgStr}GB) -> 月末予測: {$estimatedUserUsageStr}GB";
+                // Middle/end of the month (100% current month)
+                if ($detail['hasRecent']) {
+                    $dayDiff = $detail['dayDiff'];
+                    $rRecentStr = sprintf("%.2f", $detail['rRecent']);
+                    $rCumulativeStr = sprintf("%.2f", $detail['rCumulative']);
+                    $detailList[] = "  {$userName}: 日平均 {$rProjectedStr}GB [内訳: 直近{$dayDiff}日 {$rRecentStr}GB×50% + 月初来 {$rCumulativeStr}GB×50%] -> 月末予測: {$estimatedUserUsageStr}GB";
+                } else {
+                    $rCumulativeStr = sprintf("%.2f", $detail['rCumulative']);
+                    $detailList[] = "  {$userName}: 日平均 {$rProjectedStr}GB [内訳: 月初来 {$rCumulativeStr}GB(100%)] -> 月末予測: {$estimatedUserUsageStr}GB";
+                }
             }
         }
         $detailStr = implode("\n", $detailList);
@@ -319,20 +330,65 @@ EOT;
         $now = new Carbon(timezone: Consts::TIMEZONE);
         $todayStr = $now->format('Y-m-d');
         $currentYearMonth = $now->format('Y-m');
+        $prevYearMonth = $now->copy()->subMonth()->format('Y-m');
         $daysInMonth = $now->daysInMonth();
         $currentDay = $now->day;
 
         $monthlyHistory = [];
+        $prevHistory = [];
         foreach ($this->history as $dateStr => $usages) {
             if (str_starts_with($dateStr, $currentYearMonth) && $dateStr < $todayStr) {
                 $monthlyHistory[$dateStr] = $usages;
+            } elseif (str_starts_with($dateStr, $prevYearMonth)) {
+                $prevHistory[$dateStr] = $usages;
             }
         }
         krsort($monthlyHistory);
+        krsort($prevHistory);
 
         $totalEstimated = 0.0;
         $details = [];
         foreach ($monthlyUsage as $user => $currentUsage) {
+            // Baseline Rate calculation (R_baseline)
+            $rPrev = null;
+            if (!empty($prevHistory)) {
+                $prevDateStr = (string)array_key_first($prevHistory);
+                $prevUsages = $prevHistory[$prevDateStr];
+                $prevUserUsage = null;
+                if (is_object($prevUsages) && isset($prevUsages->$user)) {
+                    $prevUserUsage = (float)$prevUsages->$user;
+                } elseif (is_array($prevUsages) && isset($prevUsages[$user])) {
+                    $prevUserUsage = (float)$prevUsages[$user];
+                }
+
+                if ($prevUserUsage !== null) {
+                    $prevRecordDay = (new Carbon($prevDateStr, timezone: Consts::TIMEZONE))->day;
+                    $rPrev = $prevUserUsage / $prevRecordDay;
+                }
+            }
+
+            $userPlanVolume = 0.0;
+            if (isset($this->iijmioConfig->users->$user)) {
+                $userInfo = $this->iijmioConfig->users->$user;
+                if (is_object($userInfo) && isset($userInfo->plan_data_volume)) {
+                    $userPlanVolume = (float)$userInfo->plan_data_volume;
+                } elseif (is_array($userInfo) && isset($userInfo['plan_data_volume'])) {
+                    $userPlanVolume = (float)$userInfo['plan_data_volume'];
+                }
+            }
+
+            if ($rPrev !== null) {
+                $rBaseline = $rPrev;
+                $baselineSource = 'previous_month';
+            } else {
+                $rBaseline = ($userPlanVolume > 0.0) ? ($userPlanVolume / $daysInMonth) : 0.0;
+                $baselineSource = 'plan';
+            }
+
+            // Current Month Cumulative Rate (R_cumulative)
+            $rCumulative = $currentDay > 0 ? ($currentUsage / $currentDay) : 0.0;
+
+            // Current Month Recent 7-Day Rate (R_recent)
             $bestDateStr = null;
             $bestUserPastUsage = null;
             $bestDayDiff = null;
@@ -361,45 +417,49 @@ EOT;
                 }
             }
 
-            $estimatedUserUsage = null;
-            $detail = [];
+            $hasRecent = false;
+            $rRecent = null;
             if ($bestDateStr !== null && $bestUserPastUsage !== null && $bestDayDiff !== null) {
                 $consumption = $currentUsage - $bestUserPastUsage;
-                $avgConsumptionPerDay = max(0.0, $consumption / $bestDayDiff);
-                $remainingDays = $daysInMonth - $currentDay;
-                $estimatedUserUsage = $currentUsage + ($avgConsumptionPerDay * $remainingDays);
-
-                $pastCarbon = new Carbon($bestDateStr, timezone: Consts::TIMEZONE);
-                $this->logger?->info("User {$user}: estimated using history of {$bestDateStr}. Past: {$bestUserPastUsage}GB, Current: {$currentUsage}GB, Diff days: {$bestDayDiff}, Avg/Day: {$avgConsumptionPerDay}GB. Estimate: {$estimatedUserUsage}GB");
-
-                $detail = [
-                    'type' => 'history',
-                    'pastDate' => $pastCarbon->format('m/d'),
-                    'pastUsage' => $bestUserPastUsage,
-                    'currentUsage' => $currentUsage,
-                    'dayDiff' => $bestDayDiff,
-                    'consumption' => round($consumption, 2),
-                    'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
-                    'remainingDays' => $remainingDays,
-                    'estimatedUserUsage' => $estimatedUserUsage,
-                ];
+                $rRecent = max(0.0, $consumption / $bestDayDiff);
+                $hasRecent = true;
             }
 
-            if ($estimatedUserUsage === null) {
-                $estimatedUserUsage = ($currentUsage / $currentDay) * $daysInMonth;
-                $this->logger?->info("User {$user}: no history found. Estimate using simple proportion: {$estimatedUserUsage}GB");
-                $avgConsumptionPerDay = $currentUsage / $currentDay;
-                $remainingDays = $daysInMonth - $currentDay;
-
-                $detail = [
-                    'type' => 'simple',
-                    'currentDay' => $currentDay,
-                    'currentUsage' => $currentUsage,
-                    'avgConsumptionPerDay' => round($avgConsumptionPerDay, 4),
-                    'remainingDays' => $remainingDays,
-                    'estimatedUserUsage' => $estimatedUserUsage,
-                ];
+            // Blend Recent and Cumulative for Current Month Rate (R_current_blended)
+            if ($hasRecent && $rRecent !== null) {
+                $rCurrentBlended = 0.5 * $rRecent + 0.5 * $rCumulative;
+            } else {
+                $rCurrentBlended = $rCumulative;
             }
+
+            // Current Month Weight (W_current)
+            $wCurrent = min(1.0, ($currentDay - 1) / 7.0);
+
+            // Projected Rate (R_projected)
+            $rProjected = $wCurrent * $rCurrentBlended + (1.0 - $wCurrent) * $rBaseline;
+
+            // Estimated Usage
+            $remainingDays = $daysInMonth - $currentDay;
+            $estimatedUserUsage = $currentUsage + ($rProjected * $remainingDays);
+
+            $this->logger?->info("User {$user}: cumulative rate = {$rCumulative}GB/day, recent rate = " . ($rRecent !== null ? "{$rRecent}" : "N/A") . "GB/day, baseline rate = {$rBaseline}GB/day ({$baselineSource}), current weight = {$wCurrent}, projected rate = {$rProjected}GB/day. Estimated = {$estimatedUserUsage}GB");
+
+            $detail = [
+                'type' => 'blended',
+                'currentDay' => $currentDay,
+                'currentUsage' => $currentUsage,
+                'avgConsumptionPerDay' => round($rProjected, 4),
+                'remainingDays' => $remainingDays,
+                'estimatedUserUsage' => $estimatedUserUsage,
+                'rCumulative' => $rCumulative,
+                'rRecent' => $rRecent,
+                'rBaseline' => $rBaseline,
+                'wCurrent' => $wCurrent,
+                'hasRecent' => $hasRecent,
+                'dayDiff' => $bestDayDiff,
+                'pastDate' => $bestDateStr ? (new Carbon($bestDateStr, timezone: Consts::TIMEZONE))->format('m/d') : null,
+                'baselineSource' => $baselineSource,
+            ];
 
             $totalEstimated += $estimatedUserUsage;
             $details[$user] = $detail;

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -21,14 +21,6 @@ final class IijmioUsageTest extends TestCase
         $this->config = (object)json_decode($content, false);
     }
 
-    // public function testCrawl(): void
-    // {
-    //     $iijmio = new IijmioUsage(iijmioConfig: $this->config->iijmio);
-        // REPLACE $this->config->iijmio->mio_io and password to test
-    //     $result = Test::invokePrivateMethod($iijmio, "__crawl");
-    //     $this->assertNotEmpty($result);
-    // }
-
     public function testParseMonthlyUsagePage(): void
     {
         $content = file_get_contents(__DIR__ . "/data/monthly_usage.html");
@@ -83,8 +75,8 @@ Plan: 6.0GB
 Left: 6.5GB
 
 [予測根拠] (残り19日)
-  user1: 履歴なし。11日間で0.9GB(日平均0.08GB) -> 月末予測: 2.5GB
-  user2: 履歴なし。11日間で1.0GB(日平均0.09GB) -> 月末予測: 2.7GB
+  user1: 日平均 0.08GB [内訳: 月初来 0.08GB(100%)] -> 月末予測: 2.5GB
+  user2: 日平均 0.09GB [内訳: 月初来 0.09GB(100%)] -> 月末予測: 2.7GB
 EOT;
         $this->assertEquals($expectedMessage, $message);
 
@@ -98,7 +90,7 @@ EOT;
             ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
         );
         $this->assertTrue($isSendAlert);
-        $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 履歴なし。20日間で0.9GB(日平均0.04GB) -> 月末予測: 1.3GB\n  user2: 履歴なし。20日間で1.0GB(日平均0.05GB) -> 月末予測: 1.5GB", $message);
+        $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 日平均 0.04GB [内訳: 月初来 0.04GB(100%)] -> 月末予測: 1.4GB\n  user2: 日平均 0.05GB [内訳: 月初来 0.05GB(100%)] -> 月末予測: 1.5GB", $message);
 
         // アラートあり（使用量同じだが、日付がまだ月初に近い）
         Carbon::setTestNow(new Carbon('2024-11-09 12:00:00', timezone: Consts::TIMEZONE));
@@ -124,8 +116,8 @@ Plan: 6.0GB
 Left: 6.5GB
 
 [予測根拠] (残り21日)
-  user1: 履歴なし。9日間で0.9GB(日平均0.10GB) -> 月末予測: 3.0GB
-  user2: 履歴なし。9日間で1.0GB(日平均0.11GB) -> 月末予測: 3.3GB
+  user1: 日平均 0.10GB [内訳: 月初来 0.10GB(100%)] -> 月末予測: 3.0GB
+  user2: 日平均 0.11GB [内訳: 月初来 0.11GB(100%)] -> 月末予測: 3.3GB
 EOT;
         $this->assertEquals($expectedMessage, $message);
     }
@@ -143,7 +135,7 @@ EOT;
 
         $this->assertSame(9.9, $result);
         $this->assertCount(2, $details);
-        $this->assertSame('simple', $details['hdo12345678']['type']);
+        $this->assertSame('blended', $details['hdo12345678']['type']);
         $this->assertSame(10, $details['hdo12345678']['currentDay']);
         $this->assertSame(1.1, $details['hdo12345678']['currentUsage']);
         $this->assertSame(0.11, $details['hdo12345678']['avgConsumptionPerDay']);
@@ -176,13 +168,11 @@ EOT;
             ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
         );
 
-        $this->assertSame(7.3, $result);
-        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame(8.6, $result);
+        $this->assertSame('blended', $details['hdo12345678']['type']);
         $this->assertSame('11/06', $details['hdo12345678']['pastDate']);
-        $this->assertSame(0.7, $details['hdo12345678']['pastUsage']);
         $this->assertSame(4, $details['hdo12345678']['dayDiff']);
-        $this->assertSame(0.4, $details['hdo12345678']['consumption']);
-        $this->assertSame(0.1, $details['hdo12345678']['avgConsumptionPerDay']);
+        $this->assertSame(0.105, $details['hdo12345678']['avgConsumptionPerDay']);
         $this->assertSame(20, $details['hdo12345678']['remainingDays']);
     }
 
@@ -207,15 +197,13 @@ EOT;
             ["hdo12345678" => 1.1, "hdo22345678" => 2.2]
         );
 
-        $this->assertSame(7.7, $result);
-        $this->assertSame('history', $details['hdo12345678']['type']);
-        $this->assertSame(-0.4, $details['hdo12345678']['consumption']);
-        $this->assertSame(0.0, $details['hdo12345678']['avgConsumptionPerDay']);
+        $this->assertSame(8.8, $result);
+        $this->assertSame('blended', $details['hdo12345678']['type']);
+        $this->assertSame(0.055, $details['hdo12345678']['avgConsumptionPerDay']);
     }
 
     public function testEstimateThisMonthUsageWithMultipleHistory(): void
     {
-        // 1. Exact match (7 days ago) should be preferred.
         Carbon::setTestNow(new Carbon('2024-11-15 12:00:00', timezone: Consts::TIMEZONE));
 
         $history = [
@@ -244,15 +232,13 @@ EOT;
             ["hdo12345678" => 1.5, "hdo22345678" => 2.0]
         );
 
-        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame('blended', $details['hdo12345678']['type']);
         $this->assertSame('11/08', $details['hdo12345678']['pastDate']);
         $this->assertSame(7, $details['hdo12345678']['dayDiff']);
-        $this->assertSame(0.8, $details['hdo12345678']['pastUsage']);
     }
 
     public function testEstimateThisMonthUsageWithHistoryTieBreaking(): void
     {
-        // 2. Tie breaking: 6 days ago vs 8 days ago. 8 days ago has larger dayDiff, so should be chosen.
         Carbon::setTestNow(new Carbon('2024-11-15 12:00:00', timezone: Consts::TIMEZONE));
 
         $history = [
@@ -275,10 +261,53 @@ EOT;
             ["hdo12345678" => 1.5, "hdo22345678" => 2.0]
         );
 
-        $this->assertSame('history', $details['hdo12345678']['type']);
+        $this->assertSame('blended', $details['hdo12345678']['type']);
         $this->assertSame('11/07', $details['hdo12345678']['pastDate']);
         $this->assertSame(8, $details['hdo12345678']['dayDiff']);
-        $this->assertSame(0.7, $details['hdo12345678']['pastUsage']);
     }
 
+    public function testEstimateThisMonthUsageWithBaselineAndPreviousMonth(): void
+    {
+        // 11月4日 (経過日数 T = 4)
+        Carbon::setTestNow(new Carbon('2024-11-04 12:00:00', timezone: Consts::TIMEZONE));
+
+        $history = [
+            "2024-10-31" => [ // 前月の最終履歴レコード (31日)
+                "hdo12345678" => 3.1,
+                "hdo22345678" => 6.2
+            ]
+        ];
+
+        $iijmio = new IijmioUsage(
+            iijmioConfig: $this->config->iijmio,
+            history: $history
+        );
+
+        [$result, $details] = Test::invokePrivateMethod(
+            $iijmio,
+            "__estimateThisMonthUsage",
+            ["hdo12345678" => 0.8, "hdo22345678" => 1.6]
+        );
+
+        // hdo12345678 の期待値計算:
+        // T = 4, wCurrent = (4-1)/7 = 3/7 = 0.4285714
+        // rCumulative = 0.8 / 4 = 0.2
+        // rBaseline (前月実績) = 3.1 / 31 = 0.1
+        // rCurrentBlended = rCumulative = 0.2
+        // rProjected = 0.4285714 * 0.2 + (1 - 0.4285714) * 0.1 = 0.142857
+        // estimated = 0.8 + 0.142857 * 26 = 4.514
+
+        // hdo22345678 の期待値計算:
+        // rCumulative = 1.6 / 4 = 0.4
+        // rBaseline (前月実績) = 6.2 / 31 = 0.2
+        // rCurrentBlended = rCumulative = 0.4
+        // rProjected = 0.4285714 * 0.4 + (1 - 0.4285714) * 0.2 = 0.285714
+        // estimated = 1.6 + 0.285714 * 26 = 9.028
+
+        // Total = 4.514 + 9.028 = 13.542 => round(13.5, 1) = 13.5
+        $this->assertSame(13.5, $result);
+        $this->assertSame(0.1429, $details['hdo12345678']['avgConsumptionPerDay']);
+        $this->assertSame(0.2857, $details['hdo22345678']['avgConsumptionPerDay']);
+        $this->assertSame('previous_month', $details['hdo12345678']['baselineSource']);
+    }
 }


### PR DESCRIPTION
月末予測におけるブレを抑えるため、ブレンド予測モデルを導入しました。

1. **月初のブレ改善**:
   今月のデータが少なく不安定な最初の1週間（経過日数1〜7日目）は、前月の最終データ（履歴から算出）または契約プラン容量を基準としたベースライン値（R_baseline）を算出し、今月実績と線形補間（ブレンド）します。これにより、月初日の異常値（一時的な大量利用など）が予測全体を破壊するのを防ぎます。

2. **月中のブレ改善**:
   直近の7日間の利用実績のみに依存すると月中全体の推移が無視されてしまう課題に対し、直近7日間実績（R_recent）と月初来全期間累積実績（R_cumulative）を50/50でハイブリッドにブレンドします。これにより、長期的なベース使用と短期のトレンド変動をバランスよく反映できます。

3. **解説メッセージの日本語改善**:
   予測根拠（[予測根拠] セクション）にブレンド割合や日平均の内訳、前月ベースラインが使用された割合などが分かりやすく日本語で表示されるように出力をアップデートしました。

4. **テストコード更新**:
   すべてのテストケース（testJudgeResult, testEstimateThisMonthUsage, testEstimateThisMonthUsageWithHistory など）を新ロジックに合わせて期待値を更新し、前月履歴を考慮した月初のテストケース（testEstimateThisMonthUsageWithBaselineAndPreviousMonth）も新規追加。テストおよび静的解析（PHPStan）をパスさせています。

Fixes #50

---
*PR created automatically by Jules for task [8395224954090023861](https://jules.google.com/task/8395224954090023861) started by @yananob*