### PR TITLE
ログイン失敗時のエラーハンドリング改善およびERROR_CODE_032の原因調査

### DIFF
--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -60,6 +60,10 @@ final class IijmioUsage
                     ]
                 );
                 $this->__checkResponse($response);
+                $loginBody = json_decode((string)$response->getBody(), true);
+                if (!empty($loginBody['error'])) {
+                    throw new \Exception("Login failed with error: " . $loginBody['error']);
+                }
 
                 $this->logger?->info("Fetching top page data (coupon data)...");
                 $response = $client->post(
@@ -75,6 +79,9 @@ final class IijmioUsage
                 );
                 $this->__checkResponse($response);
                 $body = json_decode((string)$response->getBody(), true);
+                if (!empty($body['error'])) {
+                    throw new \Exception("Could not get couponData due to error: " . $body['error']);
+                }
                 if (empty($body["serviceInfoList"][0]["couponData"])) {
                     throw new \Exception("Could not get couponData: " . var_export($body, true));
                 }


### PR DESCRIPTION
プレビュー時に発生する `ERROR_CODE_032` エラーに関して、ログイン処理が失敗した際にそれを検知せず後続API（`/api/member/top`）を呼び出したことで発生していたため、ログイン成否の検知を強化しました。また、テンプレートから一部の設定ファイルを同期しました。

---
*PR created automatically by Jules for task [5825086428841546781](https://jules.google.com/task/5825086428841546781) started by @yananob*