### PR TITLE
予測根拠表示の簡略化

### DIFF
--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -285,33 +285,19 @@ final class IijmioUsage
                 }
             }
 
+            $currentUsageStr = sprintf("%.1f", $detail['currentUsage']);
+            $dailyUsageStr = sprintf("%.1f", $dailyUsages[$user]);
             $estimatedUserUsageStr = sprintf("%.1f", $detail['estimatedUserUsage']);
-            $rProjectedStr = sprintf("%.2f", $detail['avgConsumptionPerDay']);
 
-            if ($detail['wCurrent'] < 1.0) {
-                // Beginning of the month (blended with baseline)
-                $rCurrentBlended = $detail['hasRecent']
-                    ? (0.5 * $detail['rRecent'] + 0.5 * $detail['rCumulative'])
-                    : $detail['rCumulative'];
-                $rCurrentBlendedStr = sprintf("%.2f", $rCurrentBlended);
-                $rBaselineStr = sprintf("%.2f", $detail['rBaseline']);
-                $wCurrentPct = (int)round($detail['wCurrent'] * 100);
-                $wBaselinePct = 100 - $wCurrentPct;
-
-                $detailList[] = "  {$userName}: 日平均 {$rProjectedStr}GB [内訳: 今月実績 {$rCurrentBlendedStr}GB×{$wCurrentPct}% + 前月/計画 {$rBaselineStr}GB×{$wBaselinePct}%] -> 月末予測: {$estimatedUserUsageStr}GB";
-            } else {
-                // Middle/end of the month (100% current month)
-                if ($detail['hasRecent']) {
-                    $dayDiff = $detail['dayDiff'];
-                    $rRecentStr = sprintf("%.2f", $detail['rRecent']);
-                    $rCumulativeStr = sprintf("%.2f", $detail['rCumulative']);
-                    $detailList[] = "  {$userName}: 日平均 {$rProjectedStr}GB [内訳: 直近{$dayDiff}日 {$rRecentStr}GB×50% + 月初来 {$rCumulativeStr}GB×50%] -> 月末予測: {$estimatedUserUsageStr}GB";
-                } else {
-                    $rCumulativeStr = sprintf("%.2f", $detail['rCumulative']);
-                    $detailList[] = "  {$userName}: 日平均 {$rProjectedStr}GB [内訳: 月初来 {$rCumulativeStr}GB(100%)] -> 月末予測: {$estimatedUserUsageStr}GB";
-                }
-            }
+            $detailList[] = "  {$userName}: {$currentUsageStr}GB (+{$dailyUsageStr}) → {$estimatedUserUsageStr}GB";
         }
+
+        $thisMonthTotalUsageStr = sprintf("%.1f", array_sum($monthlyUsages));
+        $dailyTotalUsageStr = sprintf("%.1f", array_sum($dailyUsages));
+        $estimateUsageStr = sprintf("%.1f", $estimateUsage);
+
+        $detailList[] = "  TOTAL: {$thisMonthTotalUsageStr}GB (+{$dailyTotalUsageStr}) → {$estimateUsageStr}GB";
+
         $detailStr = implode("\n", $detailList);
 
         $message = <<<EOT

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -75,8 +75,9 @@ Plan: 6.0GB
 Left: 6.5GB
 
 [予測根拠] (残り19日)
-  user1: 日平均 0.08GB [内訳: 月初来 0.08GB(100%)] -> 月末予測: 2.5GB
-  user2: 日平均 0.09GB [内訳: 月初来 0.09GB(100%)] -> 月末予測: 2.7GB
+  user1: 0.9GB (+0.1) → 2.5GB
+  user2: 1.0GB (+0.2) → 2.7GB
+  TOTAL: 1.9GB (+0.3) → 5.2GB
 EOT;
         $this->assertEquals($expectedMessage, $message);
 
@@ -90,7 +91,7 @@ EOT;
             ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
         );
         $this->assertTrue($isSendAlert);
-        $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 日平均 0.04GB [内訳: 月初来 0.04GB(100%)] -> 月末予測: 1.4GB\n  user2: 日平均 0.05GB [内訳: 月初来 0.05GB(100%)] -> 月末予測: 1.5GB", $message);
+        $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 0.9GB (+0.1) → 1.4GB\n  user2: 1.0GB (+0.2) → 1.5GB\n  TOTAL: 1.9GB (+0.3) → 2.9GB", $message);
 
         // アラートあり（使用量同じだが、日付がまだ月初に近い）
         Carbon::setTestNow(new Carbon('2024-11-09 12:00:00', timezone: Consts::TIMEZONE));
@@ -116,8 +117,9 @@ Plan: 6.0GB
 Left: 6.5GB
 
 [予測根拠] (残り21日)
-  user1: 日平均 0.10GB [内訳: 月初来 0.10GB(100%)] -> 月末予測: 3.0GB
-  user2: 日平均 0.11GB [内訳: 月初来 0.11GB(100%)] -> 月末予測: 3.3GB
+  user1: 0.9GB (+0.1) → 3.0GB
+  user2: 1.0GB (+0.2) → 3.3GB
+  TOTAL: 1.9GB (+0.3) → 6.3GB
 EOT;
         $this->assertEquals($expectedMessage, $message);
     }


### PR DESCRIPTION
LINE画面の幅に収まるよう、予測根拠セクションを「現時点今月計 (本日増加) → 月末予測」および「TOTAL」のみの簡潔な表示に変更しました。また、テンプレートからISSUE_TEMPLATEを同期し、テストコードを更新しました。

Fixes #55

---
*PR created automatically by Jules for task [9328605684518128218](https://jules.google.com/task/9328605684518128218) started by @yananob*