### PR TITLE
月末時点の容量残り見通し項目を追加

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,6 @@ parameters:
         - templates_c (?)
         - _deploy (?)
         - _template (?)
-        - _cf-common (?)
+        - _myapps-common (?)
 
     treatPhpDocTypesAsCertain: false

--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -262,12 +262,19 @@ final class IijmioUsage
             $thisMonthUsageList[] = "  {$userName}: {$monthlyUsage}GB  (+{$dailyUsage})";
         }
         $thisMonthUsageList = implode("\n", $thisMonthUsageList);
-        $thisMonthTotalUsage = sprintf("%.1f", array_sum($monthlyUsages));
+        $thisMonthTotalUsageVal = array_sum($monthlyUsages);
+        $thisMonthTotalUsage = sprintf("%.1f", $thisMonthTotalUsageVal);
         $dailyTotalUsage = sprintf("%.1f", array_sum($dailyUsages));
-        $thisMonthTotalUsageRate = $planDataVolume > 0 ? (int)round($thisMonthTotalUsage / $planDataVolume * 100, 0) : 0;
+        $thisMonthTotalUsageRate = $planDataVolume > 0 ? (int)round($thisMonthTotalUsageVal / $planDataVolume * 100, 0) : 0;
         $estimateUsageRate = $planDataVolume > 0 ? (int)round($estimateUsage / $planDataVolume * 100, 0) : 0;
         $planDataVolumeStr = sprintf("%.1f", $planDataVolume);
-        $totalRemainingDataVolume = sprintf("%.1f", $totalRemainingDataVolume);
+        $totalRemainingDataVolumeStr = sprintf("%.1f", $totalRemainingDataVolume);
+
+        $remainingConsumption = $estimateUsage - $thisMonthTotalUsageVal;
+        $remainingConsumptionStr = sprintf("%.1f", $remainingConsumption);
+
+        $shortageOrSurplus = $remainingConsumption - $totalRemainingDataVolume;
+        $shortageOrSurplusStr = sprintf("%.1f", $shortageOrSurplus);
 
         $remainingDays = $now->daysInMonth() - $now->day;
 
@@ -309,7 +316,9 @@ Usage:
 
 EoM: {$estimateUsage}GB  ({$estimateUsageRate}%)
 Plan: {$planDataVolumeStr}GB
-Left: {$totalRemainingDataVolume}GB
+Left: {$totalRemainingDataVolumeStr}GB
+残り消費予定: {$remainingConsumptionStr}GB
+過不足予定: {$shortageOrSurplusStr}GB
 
 [予測根拠] (残り{$remainingDays}日)
 {$detailStr}

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -73,6 +73,8 @@ Usage:
 EoM: 5.2GB  (87%)
 Plan: 6.0GB
 Left: 6.5GB
+残り消費予定: 3.3GB
+過不足予定: -3.2GB
 
 [予測根拠] (残り19日)
   user1: 0.9GB (+0.1) → 2.5GB
@@ -91,6 +93,7 @@ EOT;
             ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
         );
         $this->assertTrue($isSendAlert);
+        $this->assertStringContainsString("残り消費予定: 1.0GB\n過不足予定: -5.5GB", $message);
         $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 0.9GB (+0.1) → 1.4GB\n  user2: 1.0GB (+0.2) → 1.5GB\n  TOTAL: 1.9GB (+0.3) → 2.9GB", $message);
 
         // アラートあり（使用量同じだが、日付がまだ月初に近い）
@@ -115,6 +118,8 @@ Usage:
 EoM: 6.3GB  (105%)
 Plan: 6.0GB
 Left: 6.5GB
+残り消費予定: 4.4GB
+過不足予定: -2.1GB
 
 [予測根拠] (残り21日)
   user1: 0.9GB (+0.1) → 3.0GB


### PR DESCRIPTION
月末時点の残り消費予定（EoM - Total）および過不足予定（残り消費予定 - Left）の計算処理と、レポートメッセージへの出力項目を追加しました。

Fixes #61

---
*PR created automatically by Jules for task [646156411140889061](https://jules.google.com/task/646156411140889061) started by @yananob*