### PR TITLE
過不足予定の計算式を Left - 残り消費予定 に修正

### DIFF
--- a/src/IijmioUsage.php
+++ b/src/IijmioUsage.php
@@ -273,7 +273,7 @@ final class IijmioUsage
         $remainingConsumption = $estimateUsage - $thisMonthTotalUsageVal;
         $remainingConsumptionStr = sprintf("%.1f", $remainingConsumption);
 
-        $shortageOrSurplus = $remainingConsumption - $totalRemainingDataVolume;
+        $shortageOrSurplus = $totalRemainingDataVolume - $remainingConsumption;
         $shortageOrSurplusStr = sprintf("%.1f", $shortageOrSurplus);
 
         $remainingDays = $now->daysInMonth() - $now->day;

--- a/tests/IijmioUsageTest.php
+++ b/tests/IijmioUsageTest.php
@@ -74,7 +74,7 @@ EoM: 5.2GB  (87%)
 Plan: 6.0GB
 Left: 6.5GB
 残り消費予定: 3.3GB
-過不足予定: -3.2GB
+過不足予定: 3.2GB
 
 [予測根拠] (残り19日)
   user1: 0.9GB (+0.1) → 2.5GB
@@ -93,7 +93,7 @@ EOT;
             ["hdo12345678" => 0.1, "hdo22345678" => 0.2],
         );
         $this->assertTrue($isSendAlert);
-        $this->assertStringContainsString("残り消費予定: 1.0GB\n過不足予定: -5.5GB", $message);
+        $this->assertStringContainsString("残り消費予定: 1.0GB\n過不足予定: 5.5GB", $message);
         $this->assertStringContainsString("[予測根拠] (残り10日)\n  user1: 0.9GB (+0.1) → 1.4GB\n  user2: 1.0GB (+0.2) → 1.5GB\n  TOTAL: 1.9GB (+0.3) → 2.9GB", $message);
 
         // アラートあり（使用量同じだが、日付がまだ月初に近い）
@@ -119,7 +119,7 @@ EoM: 6.3GB  (105%)
 Plan: 6.0GB
 Left: 6.5GB
 残り消費予定: 4.4GB
-過不足予定: -2.1GB
+過不足予定: 2.1GB
 
 [予測根拠] (残り21日)
   user1: 0.9GB (+0.1) → 3.0GB


### PR DESCRIPTION
「過不足予定」の計算式を 残り消費予定 - Left から Left - 残り消費予定 に修正し、あわせて単体テストの期待値を更新しました。

Fixes #61

---
*PR created automatically by Jules for task [6466811233072102126](https://jules.google.com/task/6466811233072102126) started by @yananob*