### PR TITLE
refactor: ConfigControllerのクラス分割とService層への分離

### DIFF
--- a/src/Controllers/ConfigController.php
+++ b/src/Controllers/ConfigController.php
@@ -3,134 +3,45 @@
 namespace App\Controllers;
 
 use App\AppConfig;
-use App\Firestore;
-use App\IijmioUsage;
-use App\Utils\Logger;
+use App\Services\ConfigServiceInterface;
+use App\Services\FirestoreConfigService;
+use App\Services\MockConfigService;
 use eftec\bladeone\BladeOne;
 use Psr\Http\Message\ServerRequestInterface;
 
 final class ConfigController
 {
+    private ?ConfigServiceInterface $service;
+
+    public function __construct(?ConfigServiceInterface $service = null)
+    {
+        $this->service = $service;
+    }
+
     public function handle(ServerRequestInterface $request): string
     {
         $isMock = ($request->getQueryParams()['mock'] ?? false) || (getenv('MOCK_FIRESTORE') === '1');
         $collectionName = AppConfig::getCollectionName();
+
+        $service = $this->service ?? ($isMock
+            ? new MockConfigService()
+            : new FirestoreConfigService($collectionName));
+
         $message = null;
         $previewMessage = null;
 
-        if ($isMock) {
-            $configData = [
-                'iijmio' => [
-                    'mio_id' => 'MA1234567',
-                    'password' => 'supersecret',
-                    'users' => [
-                        'hdo11111111' => [
-                            'name' => 'Alice',
-                            'plan_data_volume' => 5.0
-                        ],
-                        'hdo22222222' => [
-                            'name' => 'Bob',
-                            'plan_data_volume' => 10.0
-                        ]
-                    ]
-                ],
-                'alert' => [
-                    'bot' => 'MyLineBot',
-                    'target' => 'MyGroup',
-                    'send_usage_each_n_days' => 3
-                ]
-            ];
+        if ($request->getMethod() === 'POST') {
+            $params = (array)$request->getParsedBody();
+            $configData = $service->parseConfigFromParams($params);
+            $action = $params['action'] ?? 'save';
 
-            if ($request->getMethod() === 'POST') {
-                $params = (array)$request->getParsedBody();
-                $users = [];
-                if (isset($params['iijmio']['users']) && is_array($params['iijmio']['users'])) {
-                    foreach ($params['iijmio']['users'] as $user) {
-                        if (!empty($user['code']) && !empty($user['name'])) {
-                            $users[$user['code']] = [
-                                'name' => $user['name'],
-                                'plan_data_volume' => (float)($user['plan_data_volume'] ?? 0),
-                            ];
-                        }
-                    }
-                }
-                $configData = [
-                    'iijmio' => [
-                        'mio_id' => $params['iijmio']['mio_id'] ?? '',
-                        'password' => $params['iijmio']['password'] ?? '',
-                        'users' => $users,
-                    ],
-                    'alert' => [
-                        'bot' => $params['alert']['bot'] ?? '',
-                        'target' => $params['alert']['target'] ?? '',
-                        'send_usage_each_n_days' => (int)($params['alert']['send_usage_each_n_days'] ?? 0),
-                    ],
-                ];
-
-                $action = $params['action'] ?? 'save';
-                if ($action === 'save') {
-                    $message = "Config updated successfully. (Mock Save)";
-                } elseif ($action === 'preview') {
-                    $previewMessage = "[IIJmioデータ利用状況]\n- Alice (hdo11111111): 1.2 GB / 5.0 GB\n- Bob (hdo22222222): 4.5 GB / 10.0 GB\n\n[予測根拠]\nAlice: 直近3日間の平均から算出。\nBob: 直近3日間の平均から算出。";
-                }
+            if ($action === 'save') {
+                $message = $service->saveConfig($configData);
+            } elseif ($action === 'preview') {
+                $previewMessage = $service->generatePreview($configData);
             }
         } else {
-            $firestore = Firestore::getClient();
-            $docRef = $firestore->collection($collectionName)->document('config');
-            if ($request->getMethod() === 'POST') {
-                $params = (array)$request->getParsedBody();
-
-                $users = [];
-                if (isset($params['iijmio']['users']) && is_array($params['iijmio']['users'])) {
-                    foreach ($params['iijmio']['users'] as $user) {
-                        if (!empty($user['code']) && !empty($user['name'])) {
-                            $users[$user['code']] = [
-                                'name' => $user['name'],
-                                'plan_data_volume' => (float)($user['plan_data_volume'] ?? 0),
-                            ];
-                        }
-                    }
-                }
-
-                $configData = [
-                    'iijmio' => [
-                        'mio_id' => $params['iijmio']['mio_id'] ?? '',
-                        'password' => $params['iijmio']['password'] ?? '',
-                        'users' => $users,
-                    ],
-                    'alert' => [
-                        'bot' => $params['alert']['bot'] ?? '',
-                        'target' => $params['alert']['target'] ?? '',
-                        'send_usage_each_n_days' => (int)($params['alert']['send_usage_each_n_days'] ?? 0),
-                    ],
-                ];
-
-                $action = $params['action'] ?? 'save';
-                if ($action === 'save') {
-                    $docRef->set($configData);
-                    $message = "Config updated successfully.";
-                } elseif ($action === 'preview') {
-                    $configObj = (object)json_decode((string)json_encode($configData));
-                    $logger = new Logger("preview");
-                    $historyDoc = $firestore->collection($collectionName)->document('history')->snapshot();
-                    $history = $historyDoc->exists() ? (array)$historyDoc->data() : [];
-
-                    $iijmio = new IijmioUsage(
-                        $configObj->iijmio,
-                        $configObj->alert->send_usage_each_n_days,
-                        $logger,
-                        $history
-                    );
-                    try {
-                        [, $previewMessage] = $iijmio->getStats();
-                    } catch (\Exception $e) {
-                        $previewMessage = "Error: " . $e->getMessage();
-                    }
-                }
-            } else {
-                $doc = $docRef->snapshot();
-                $configData = $doc->exists() ? (array)$doc->data() : [];
-            }
+            $configData = $service->getConfig();
         }
 
         $views = dirname(__DIR__, 2) . '/views';
@@ -142,7 +53,7 @@ final class ConfigController
 
         return $blade->run("config", [
             "message" => $message,
-            "previewMessage" => $previewMessage ?? null,
+            "previewMessage" => $previewMessage,
             "collectionName" => $collectionName,
             "config" => $configData,
             "appEnv" => getenv('APP_ENV') ?: 'unknown',

--- a/src/Services/ConfigServiceInterface.php
+++ b/src/Services/ConfigServiceInterface.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+interface ConfigServiceInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array;
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function parseConfigFromParams(array $params): array;
+
+    /**
+     * @param array<string, mixed> $configData
+     * @return string
+     */
+    public function saveConfig(array $configData): string;
+
+    /**
+     * @param array<string, mixed> $configData
+     * @return string
+     */
+    public function generatePreview(array $configData): string;
+}

--- a/src/Services/FirestoreConfigService.php
+++ b/src/Services/FirestoreConfigService.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Firestore;
+use App\IijmioUsage;
+use App\Utils\Logger;
+
+final class FirestoreConfigService implements ConfigServiceInterface
+{
+    private string $collectionName;
+
+    public function __construct(string $collectionName)
+    {
+        $this->collectionName = $collectionName;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        $firestore = Firestore::getClient();
+        $doc = $firestore->collection($this->collectionName)->document('config')->snapshot();
+        return $doc->exists() ? (array)$doc->data() : [];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function parseConfigFromParams(array $params): array
+    {
+        $users = [];
+        if (isset($params['iijmio']['users']) && is_array($params['iijmio']['users'])) {
+            foreach ($params['iijmio']['users'] as $user) {
+                if (is_array($user) && !empty($user['code']) && !empty($user['name'])) {
+                    $users[(string)$user['code']] = [
+                        'name' => (string)$user['name'],
+                        'plan_data_volume' => (float)($user['plan_data_volume'] ?? 0),
+                    ];
+                }
+            }
+        }
+
+        $iijmio = is_array($params['iijmio'] ?? null) ? $params['iijmio'] : [];
+        $alert = is_array($params['alert'] ?? null) ? $params['alert'] : [];
+
+        return [
+            'iijmio' => [
+                'mio_id' => (string)($iijmio['mio_id'] ?? ''),
+                'password' => (string)($iijmio['password'] ?? ''),
+                'users' => $users,
+            ],
+            'alert' => [
+                'bot' => (string)($alert['bot'] ?? ''),
+                'target' => (string)($alert['target'] ?? ''),
+                'send_usage_each_n_days' => (int)($alert['send_usage_each_n_days'] ?? 0),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $configData
+     * @return string
+     */
+    public function saveConfig(array $configData): string
+    {
+        $firestore = Firestore::getClient();
+        $docRef = $firestore->collection($this->collectionName)->document('config');
+        $docRef->set($configData);
+        return "Config updated successfully.";
+    }
+
+    /**
+     * @param array<string, mixed> $configData
+     * @return string
+     */
+    public function generatePreview(array $configData): string
+    {
+        $firestore = Firestore::getClient();
+        $configObj = (object)json_decode((string)json_encode($configData));
+        $logger = new Logger("preview");
+        $historyDoc = $firestore->collection($this->collectionName)->document('history')->snapshot();
+        $history = $historyDoc->exists() ? (array)$historyDoc->data() : [];
+
+        $iijmio = new IijmioUsage(
+            $configObj->iijmio,
+            $configObj->alert->send_usage_each_n_days,
+            $logger,
+            $history
+        );
+
+        try {
+            [, $previewMessage] = $iijmio->getStats();
+            return $previewMessage;
+        } catch (\Throwable $e) {
+            return "Error: " . $e->getMessage();
+        }
+    }
+}

--- a/src/Services/MockConfigService.php
+++ b/src/Services/MockConfigService.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+final class MockConfigService implements ConfigServiceInterface
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $configData = [
+        'iijmio' => [
+            'mio_id' => 'MA1234567',
+            'password' => 'supersecret',
+            'users' => [
+                'hdo11111111' => [
+                    'name' => 'Alice',
+                    'plan_data_volume' => 5.0
+                ],
+                'hdo22222222' => [
+                    'name' => 'Bob',
+                    'plan_data_volume' => 10.0
+                ]
+            ]
+        ],
+        'alert' => [
+            'bot' => 'MyLineBot',
+            'target' => 'MyGroup',
+            'send_usage_each_n_days' => 3
+        ]
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->configData;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function parseConfigFromParams(array $params): array
+    {
+        $users = [];
+        if (isset($params['iijmio']['users']) && is_array($params['iijmio']['users'])) {
+            foreach ($params['iijmio']['users'] as $user) {
+                if (is_array($user) && !empty($user['code']) && !empty($user['name'])) {
+                    $users[(string)$user['code']] = [
+                        'name' => (string)$user['name'],
+                        'plan_data_volume' => (float)($user['plan_data_volume'] ?? 0),
+                    ];
+                }
+            }
+        }
+
+        $iijmio = is_array($params['iijmio'] ?? null) ? $params['iijmio'] : [];
+        $alert = is_array($params['alert'] ?? null) ? $params['alert'] : [];
+
+        return [
+            'iijmio' => [
+                'mio_id' => (string)($iijmio['mio_id'] ?? ''),
+                'password' => (string)($iijmio['password'] ?? ''),
+                'users' => $users,
+            ],
+            'alert' => [
+                'bot' => (string)($alert['bot'] ?? ''),
+                'target' => (string)($alert['target'] ?? ''),
+                'send_usage_each_n_days' => (int)($alert['send_usage_each_n_days'] ?? 0),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $configData
+     * @return string
+     */
+    public function saveConfig(array $configData): string
+    {
+        $this->configData = $configData;
+        return "Config updated successfully. (Mock Save)";
+    }
+
+    /**
+     * @param array<string, mixed> $configData
+     * @return string
+     */
+    public function generatePreview(array $configData): string
+    {
+        return "[IIJmioデータ利用状況]\n- Alice (hdo11111111): 1.2 GB / 5.0 GB\n- Bob (hdo22222222): 4.5 GB / 10.0 GB\n\n[予測根拠]\nAlice: 直近3日間の平均から算出。\nBob: 直近3日間の平均から算出。";
+    }
+}

--- a/tests/ConfigControllerTest.php
+++ b/tests/ConfigControllerTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Tests;
+
+use App\Controllers\ConfigController;
+use App\Services\MockConfigService;
+use GuzzleHttp\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigControllerTest extends TestCase
+{
+    public function testHandleGetRequestMock(): void
+    {
+        $request = (new ServerRequest('GET', '/'))->withQueryParams(['mock' => '1']);
+        $controller = new ConfigController();
+        $html = $controller->handle($request);
+
+        $this->assertStringContainsString('<title>IIJmio Usage Checker Config</title>', $html);
+        $this->assertStringContainsString('MA1234567', $html);
+        $this->assertStringContainsString('Alice', $html);
+    }
+
+    public function testHandlePostSaveMock(): void
+    {
+        $request = (new ServerRequest('POST', '/'))
+            ->withQueryParams(['mock' => '1'])
+            ->withParsedBody([
+                'action' => 'save',
+                'iijmio' => [
+                    'mio_id' => 'MA9999999',
+                    'password' => 'newpassword',
+                    'users' => [
+                        ['code' => 'hdo123', 'name' => 'Charlie', 'plan_data_volume' => '10']
+                    ]
+                ],
+                'alert' => [
+                    'bot' => 'TestBot',
+                    'target' => 'TestTarget',
+                    'send_usage_each_n_days' => '2'
+                ]
+            ]);
+
+        $controller = new ConfigController();
+        $html = $controller->handle($request);
+
+        $this->assertStringContainsString('Config updated successfully. (Mock Save)', $html);
+        $this->assertStringContainsString('MA9999999', $html);
+        $this->assertStringContainsString('Charlie', $html);
+    }
+
+    public function testHandlePostPreviewMock(): void
+    {
+        $request = (new ServerRequest('POST', '/'))
+            ->withQueryParams(['mock' => '1'])
+            ->withParsedBody([
+                'action' => 'preview',
+                'iijmio' => [
+                    'mio_id' => 'MA1234567',
+                    'password' => 'secret',
+                    'users' => [
+                        ['code' => 'hdo11111111', 'name' => 'Alice', 'plan_data_volume' => '5']
+                    ]
+                ],
+                'alert' => [
+                    'bot' => 'MyLineBot',
+                    'target' => 'MyGroup',
+                    'send_usage_each_n_days' => '3'
+                ]
+            ]);
+
+        $controller = new ConfigController();
+        $html = $controller->handle($request);
+
+        $this->assertStringContainsString('[IIJmioデータ利用状況]', $html);
+    }
+
+    public function testMockConfigServiceParseConfigFromParams(): void
+    {
+        $service = new MockConfigService();
+        $parsed = $service->parseConfigFromParams([
+            'iijmio' => [
+                'mio_id' => 'MA5555555',
+                'password' => 'pass123',
+                'users' => [
+                    ['code' => 'hdo111', 'name' => 'User1', 'plan_data_volume' => '2'],
+                    ['code' => '', 'name' => 'InvalidUser'], // should be skipped
+                ]
+            ],
+            'alert' => [
+                'bot' => 'Bot1',
+                'target' => 'Target1',
+                'send_usage_each_n_days' => '5'
+            ]
+        ]);
+
+        $expected = [
+            'iijmio' => [
+                'mio_id' => 'MA5555555',
+                'password' => 'pass123',
+                'users' => [
+                    'hdo111' => [
+                        'name' => 'User1',
+                        'plan_data_volume' => 2.0
+                    ]
+                ]
+            ],
+            'alert' => [
+                'bot' => 'Bot1',
+                'target' => 'Target1',
+                'send_usage_each_n_days' => 5
+            ]
+        ];
+
+        $this->assertSame($expected, $parsed);
+    }
+
+    public function testConfigControllerWithInjectedService(): void
+    {
+        $mockService = new MockConfigService();
+        $controller = new ConfigController($mockService);
+        $request = new ServerRequest('GET', '/');
+        $html = $controller->handle($request);
+
+        $this->assertStringContainsString('<title>IIJmio Usage Checker Config</title>', $html);
+        $this->assertStringContainsString('MA1234567', $html);
+    }
+}


### PR DESCRIPTION
`ConfigController` の責任を分離し、設定のパース・取得・保存およびプレビュー生成を行う `ConfigServiceInterface` とその実装クラス (`MockConfigService` / `FirestoreConfigService`) に処理を移譲しました。また、`ConfigControllerTest` を作成しユニットテストを追加しました。

---
*PR created automatically by Jules for task [15047548990730797315](https://jules.google.com/task/15047548990730797315) started by @yananob*