### PR TITLE
画面改善（レイアウト整理・日別グラフの累積切替および月末予測トレンドライン追加）

### DIFF
--- a/src/Services/FirestoreConfigService.php
+++ b/src/Services/FirestoreConfigService.php
@@ -192,6 +192,8 @@ final class FirestoreConfigService implements ConfigServiceInterface
                 'date' => $dateStr,
                 'usages' => $dailyCalculated,
                 'total' => round($totalDaily, 3),
+                'cumulativeUsages' => $dateUsages,
+                'cumulativeTotal' => round(array_sum($dateUsages), 3),
             ];
 
             $monthlyLatest[$currentMonth] = $dateUsages;

--- a/src/Services/MockConfigService.php
+++ b/src/Services/MockConfigService.php
@@ -205,6 +205,8 @@ EOT;
                 'date' => $dateStr,
                 'usages' => $dailyCalculated,
                 'total' => round($totalDaily, 3),
+                'cumulativeUsages' => $usages,
+                'cumulativeTotal' => round(array_sum($usages), 3),
             ];
 
             $monthlyLatest[$currentMonth] = $usages;

--- a/tests/ConfigControllerTest.php
+++ b/tests/ConfigControllerTest.php
@@ -38,7 +38,7 @@ final class ConfigControllerTest extends TestCase
         $html = $controller->handle($request);
 
         $this->assertStringContainsString('<title>IIJmio Usage Checker - 日別グラフ</title>', $html);
-        $this->assertStringContainsString('月別グラフ画面へ', $html);
+        $this->assertStringContainsString('月別画面へ', $html);
     }
 
     public function testHandleGetRequestMonthlyMock(): void
@@ -48,7 +48,7 @@ final class ConfigControllerTest extends TestCase
         $html = $controller->handle($request);
 
         $this->assertStringContainsString('<title>IIJmio Usage Checker - 月別グラフ</title>', $html);
-        $this->assertStringContainsString('日別グラフ画面へ', $html);
+        $this->assertStringContainsString('日別画面へ', $html);
     }
 
     public function testHandleApiUsageMock(): void
@@ -76,6 +76,10 @@ final class ConfigControllerTest extends TestCase
         $this->assertArrayHasKey('daily', $data);
         $this->assertArrayHasKey('monthly', $data);
         $this->assertSame('Alice', $data['users']['hdo11111111']);
+
+        $firstDaily = $data['daily'][0];
+        $this->assertArrayHasKey('cumulativeUsages', $firstDaily);
+        $this->assertArrayHasKey('cumulativeTotal', $firstDaily);
     }
 
     public function testHandlePostSaveMock(): void

--- a/views/daily.blade.php
+++ b/views/daily.blade.php
@@ -10,60 +10,69 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="h-full text-slate-800 font-sans antialiased">
-    <div class="min-h-screen py-10 px-4 sm:px-6 lg:px-8 flex flex-col justify-between">
-        <div class="max-w-4xl w-full mx-auto bg-white rounded-2xl shadow-xl border border-slate-100 overflow-hidden mb-12">
+    <div class="min-h-screen py-3 sm:py-6 px-3 sm:px-6 lg:px-8 flex flex-col justify-between">
+        <div class="max-w-4xl w-full mx-auto bg-white rounded-2xl shadow-md border border-slate-100 overflow-hidden mb-4">
             <!-- Navigation Header -->
             @include('nav')
 
-            <div class="p-6 sm:p-10 space-y-8">
+            <div class="p-4 sm:p-6 space-y-5">
                 <!-- Transition Banner to Monthly View -->
-                <div class="flex flex-col sm:flex-row items-center justify-between gap-4 p-4 bg-indigo-50 border border-indigo-100 rounded-xl">
-                    <div class="text-sm font-medium text-indigo-900">
-                        日ごとの個人別利用量グラフを表示しています。月ごとの推移を見るには月別グラフへお進みください。
+                <div class="flex flex-col sm:flex-row items-center justify-between gap-3 p-3.5 bg-indigo-50 border border-indigo-100 rounded-xl">
+                    <div class="text-xs sm:text-sm font-medium text-indigo-900">
+                        日ごとの個人別利用量グラフを表示しています。月ごとの推移を見るには月別画面へお進みください。
                     </div>
-                    <a href="?page=monthly" class="shrink-0 inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs rounded-lg transition active:scale-95 shadow-sm">
-                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                    <a href="?page=monthly" class="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs rounded-lg transition active:scale-95 shadow-sm">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
                         </svg>
-                        月別グラフ画面へ
+                        月別画面へ
                     </a>
                 </div>
 
                 <!-- Loading Skeleton -->
-                <div id="loading-skeleton" class="space-y-6 animate-pulse">
+                <div id="loading-skeleton" class="space-y-4 animate-pulse">
                     <div class="h-8 bg-slate-200 rounded-lg w-1/3"></div>
                     <div class="h-80 bg-slate-100 rounded-2xl"></div>
                 </div>
 
                 <!-- Error Container -->
-                <div id="error-container" class="hidden p-6 bg-rose-50 border border-rose-200 text-rose-800 rounded-xl">
+                <div id="error-container" class="hidden p-4 bg-rose-50 border border-rose-200 text-rose-800 rounded-xl">
                     <div class="flex items-center gap-3">
-                        <svg class="w-6 h-6 text-rose-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <svg class="w-5 h-5 text-rose-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                         </svg>
                         <div>
-                            <h3 class="font-bold text-base">履歴データの読み込みに失敗しました</h3>
-                            <p class="text-sm mt-1" id="error-message">通信エラーが発生しました。</p>
+                            <h3 class="font-bold text-sm">履歴データの読み込みに失敗しました</h3>
+                            <p class="text-xs mt-0.5" id="error-message">通信エラーが発生しました。</p>
                         </div>
                     </div>
                 </div>
 
                 <!-- Content Container -->
-                <div id="content-container" class="hidden space-y-8">
-                    <div class="bg-slate-50/60 p-6 rounded-2xl border border-slate-100 space-y-4">
-                        <div class="flex items-center justify-between border-b border-slate-200/60 pb-3">
-                            <h2 class="text-lg font-extrabold text-slate-800">日別・個人別使用量 (GB)</h2>
+                <div id="content-container" class="hidden space-y-5">
+                    <div class="bg-slate-50/60 p-4 sm:p-5 rounded-2xl border border-slate-100 space-y-4">
+                        <div class="flex flex-col sm:flex-row sm:items-center justify-between border-b border-slate-200/60 pb-3 gap-3">
+                            <h2 class="text-base font-extrabold text-slate-800" id="chart-title">日別・個人別使用量 (GB)</h2>
+                            <!-- Toggle Button Group -->
+                            <div class="inline-flex p-1 bg-slate-200/80 rounded-xl space-x-1 shrink-0 self-start sm:self-auto">
+                                <button id="btn-mode-daily" onclick="switchMode('daily')" class="px-3 py-1.5 rounded-lg text-xs font-bold transition-all bg-indigo-600 text-white shadow-sm">
+                                    日ごと
+                                </button>
+                                <button id="btn-mode-cumulative" onclick="switchMode('cumulative')" class="px-3 py-1.5 rounded-lg text-xs font-bold transition-all text-slate-600 hover:text-slate-900">
+                                    累積
+                                </button>
+                            </div>
                         </div>
-                        <div class="relative h-80 sm:h-96">
+                        <div class="relative h-72 sm:h-80">
                             <canvas id="dailyChart"></canvas>
                         </div>
                     </div>
 
                     <!-- History Table -->
-                    <div class="bg-slate-50/60 p-6 rounded-2xl border border-slate-100 space-y-4">
-                        <h3 class="text-md font-extrabold text-slate-800">日別使用量 履歴テーブル</h3>
+                    <div class="bg-slate-50/60 p-4 sm:p-5 rounded-2xl border border-slate-100 space-y-3">
+                        <h3 class="text-sm font-extrabold text-slate-800" id="table-title">日別使用量 履歴テーブル</h3>
                         <div class="overflow-x-auto border border-slate-200/80 rounded-xl bg-white shadow-sm">
-                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <table class="min-w-full divide-y divide-slate-200 text-xs sm:text-sm">
                                 <thead class="bg-slate-50" id="daily-table-head">
                                 </thead>
                                 <tbody id="daily-table-body" class="divide-y divide-slate-200">
@@ -74,94 +83,201 @@
                 </div>
             </div>
         </div>
-
-        <div class="text-center text-xs text-slate-400 font-medium pb-4">
-            IIJmio Usage Checker &bull; Environment: <span class="px-2 py-0.5 rounded bg-slate-200 text-slate-600 font-mono">{{ $appEnv }}</span>
-        </div>
     </div>
 
     <script>
+        let currentMode = 'daily'; // 'daily' or 'cumulative'
+        let historyDataGlobal = null;
+        let usageDataGlobal = null;
+        let dailyChartInstance = null;
+
         document.addEventListener('DOMContentLoaded', function() {
             const currentParams = new URLSearchParams(window.location.search);
-            currentParams.set('action', 'api_history');
-            const apiUrl = '?' + currentParams.toString();
 
-            fetch(apiUrl)
-                .then(res => {
+            const historyParams = new URLSearchParams(currentParams);
+            historyParams.set('action', 'api_history');
+            const historyUrl = '?' + historyParams.toString();
+
+            const usageParams = new URLSearchParams(currentParams);
+            usageParams.set('action', 'api_usage');
+            const usageUrl = '?' + usageParams.toString();
+
+            Promise.all([
+                fetch(historyUrl).then(res => {
                     if (!res.ok) throw new Error('HTTP ' + res.status);
                     return res.json();
-                })
-                .then(data => {
-                    renderDailyChart(data);
-                })
-                .catch(err => {
-                    document.getElementById('loading-skeleton').classList.add('hidden');
-                    document.getElementById('error-container').classList.remove('hidden');
-                    document.getElementById('error-message').textContent = err.message || '読み込み失敗';
-                });
+                }),
+                fetch(usageUrl).then(res => {
+                    if (!res.ok) return null;
+                    return res.json();
+                }).catch(() => null)
+            ])
+            .then(([historyData, usageData]) => {
+                historyDataGlobal = historyData;
+                usageDataGlobal = usageData;
+                renderDashboard();
+            })
+            .catch(err => {
+                document.getElementById('loading-skeleton').classList.add('hidden');
+                document.getElementById('error-container').classList.remove('hidden');
+                document.getElementById('error-message').textContent = err.message || '読み込み失敗';
+            });
         });
 
-        function renderDailyChart(data) {
+        function switchMode(mode) {
+            currentMode = mode;
+            const btnDaily = document.getElementById('btn-mode-daily');
+            const btnCumulative = document.getElementById('btn-mode-cumulative');
+
+            if (mode === 'daily') {
+                btnDaily.className = 'px-3 py-1.5 rounded-lg text-xs font-bold transition-all bg-indigo-600 text-white shadow-sm';
+                btnCumulative.className = 'px-3 py-1.5 rounded-lg text-xs font-bold transition-all text-slate-600 hover:text-slate-900';
+            } else {
+                btnCumulative.className = 'px-3 py-1.5 rounded-lg text-xs font-bold transition-all bg-indigo-600 text-white shadow-sm';
+                btnDaily.className = 'px-3 py-1.5 rounded-lg text-xs font-bold transition-all text-slate-600 hover:text-slate-900';
+            }
+
+            renderDashboard();
+        }
+
+        function renderDashboard() {
+            if (!historyDataGlobal) return;
+
             document.getElementById('loading-skeleton').classList.add('hidden');
             document.getElementById('content-container').classList.remove('hidden');
 
-            const users = data.users || {};
+            const users = historyDataGlobal.users || {};
             const userKeys = Object.keys(users);
-            const dailyData = data.daily || [];
-
-            const labels = dailyData.map(d => d.date);
+            const dailyData = historyDataGlobal.daily || [];
 
             const colors = ['#6366f1', '#10b981', '#f59e0b', '#ec4899', '#8b5cf6', '#06b6d4'];
 
-            const datasets = userKeys.map((key, idx) => {
-                return {
-                    label: users[key] || key,
-                    data: dailyData.map(d => d.usages[key] || 0),
-                    backgroundColor: colors[idx % colors.length],
-                    borderRadius: 4
-                };
-            });
+            if (dailyChartInstance) {
+                dailyChartInstance.destroy();
+            }
 
             const ctx = document.getElementById('dailyChart').getContext('2d');
-            new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: labels,
-                    datasets: datasets
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        legend: { position: 'bottom' },
-                        title: { display: true, text: '日別データ使用量 (GB)', font: { size: 14, weight: 'bold' } }
-                    },
-                    scales: {
-                        x: { stacked: true },
-                        y: { stacked: true, beginAtZero: true }
-                    }
-                }
-            });
 
-            // Table rendering
+            if (currentMode === 'daily') {
+                document.getElementById('chart-title').textContent = '日別・個人別使用量 (GB)';
+                document.getElementById('table-title').textContent = '日別使用量 履歴テーブル';
+
+                const labels = dailyData.map(d => d.date);
+                const datasets = userKeys.map((key, idx) => ({
+                    type: 'bar',
+                    label: users[key] || key,
+                    data: dailyData.map(d => d.usages[key] ?? 0),
+                    backgroundColor: colors[idx % colors.length],
+                    borderRadius: 4,
+                    stack: 'dailyStack'
+                }));
+
+                dailyChartInstance = new Chart(ctx, {
+                    data: { labels: labels, datasets: datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            legend: { position: 'bottom' },
+                            title: { display: true, text: '日別データ使用量 (GB)', font: { size: 14, weight: 'bold' } }
+                        },
+                        scales: {
+                            x: { stacked: true },
+                            y: { stacked: true, beginAtZero: true }
+                        }
+                    }
+                });
+            } else {
+                // Cumulative Mode
+                document.getElementById('chart-title').textContent = '累積使用量 ＆ 月末予測 (GB)';
+                document.getElementById('table-title').textContent = '累積使用量 履歴テーブル';
+
+                const labels = dailyData.map(d => d.date);
+
+                const datasets = userKeys.map((key, idx) => ({
+                    type: 'bar',
+                    label: users[key] || key,
+                    data: dailyData.map(d => (d.cumulativeUsages ? d.cumulativeUsages[key] : null) ?? d.usages[key] ?? 0),
+                    backgroundColor: colors[idx % colors.length],
+                    borderRadius: 4,
+                    stack: 'cumStack'
+                }));
+
+                // Add End-of-Month prediction trendline for current month
+                if (usageDataGlobal && usageDataGlobal.estimateUsage && dailyData.length > 0) {
+                    const latestDate = dailyData[dailyData.length - 1].date;
+                    const latestMonth = latestDate.substring(0, 7);
+
+                    labels.push('月末予測');
+                    datasets.forEach(ds => ds.data.push(null));
+
+                    const totalTrendData = dailyData.map(d => {
+                        if (d.date.startsWith(latestMonth)) {
+                            return d.cumulativeTotal ?? d.total ?? 0;
+                        }
+                        return null;
+                    });
+                    totalTrendData.push(usageDataGlobal.estimateUsage);
+
+                    datasets.push({
+                        type: 'line',
+                        label: `月末予測トレンド (${usageDataGlobal.estimateUsage} GB)`,
+                        data: totalTrendData,
+                        borderColor: '#f59e0b',
+                        backgroundColor: '#f59e0b',
+                        borderWidth: 2.5,
+                        borderDash: [6, 6],
+                        pointRadius: 4,
+                        pointHoverRadius: 6,
+                        fill: false,
+                        tension: 0.1,
+                        spanGaps: true
+                    });
+                }
+
+                dailyChartInstance = new Chart(ctx, {
+                    data: { labels: labels, datasets: datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            legend: { position: 'bottom' },
+                            title: { display: true, text: '累積データ使用量・月末予測 (GB)', font: { size: 14, weight: 'bold' } }
+                        },
+                        scales: {
+                            x: { stacked: true },
+                            y: { stacked: true, beginAtZero: true }
+                        }
+                    }
+                });
+            }
+
+            // Render Table
             const thead = document.getElementById('daily-table-head');
-            let headHtml = `<tr><th class="px-4 py-3 text-left font-bold text-slate-500">日付</th>`;
+            let headHtml = `<tr><th class="px-3.5 py-2.5 text-left font-bold text-slate-500">日付</th>`;
             userKeys.forEach(k => {
-                headHtml += `<th class="px-4 py-3 text-right font-bold text-slate-500">${users[k]}</th>`;
+                headHtml += `<th class="px-3.5 py-2.5 text-right font-bold text-slate-500">${users[k]}</th>`;
             });
-            headHtml += `<th class="px-4 py-3 text-right font-bold text-slate-700">合計</th></tr>`;
+            headHtml += `<th class="px-3.5 py-2.5 text-right font-bold text-slate-700">合計</th></tr>`;
             thead.innerHTML = headHtml;
 
             const tbody = document.getElementById('daily-table-body');
             tbody.innerHTML = '';
+
             dailyData.slice().reverse().forEach(row => {
                 const tr = document.createElement('tr');
                 tr.className = 'hover:bg-slate-50/50 transition-colors';
-                let rowHtml = `<td class="px-4 py-3 font-semibold text-slate-800">${row.date}</td>`;
+                let rowHtml = `<td class="px-3.5 py-2.5 font-semibold text-slate-800">${row.date}</td>`;
                 userKeys.forEach(k => {
-                    rowHtml += `<td class="px-4 py-3 text-right text-slate-600">${row.usages[k] ?? 0} GB</td>`;
+                    const val = currentMode === 'daily'
+                        ? (row.usages[k] ?? 0)
+                        : ((row.cumulativeUsages ? row.cumulativeUsages[k] : null) ?? row.usages[k] ?? 0);
+                    rowHtml += `<td class="px-3.5 py-2.5 text-right text-slate-600">${val} GB</td>`;
                 });
-                rowHtml += `<td class="px-4 py-3 text-right font-bold text-indigo-600">${row.total} GB</td>`;
+                const totalVal = currentMode === 'daily'
+                    ? (row.total ?? 0)
+                    : (row.cumulativeTotal ?? row.total ?? 0);
+                rowHtml += `<td class="px-3.5 py-2.5 text-right font-bold text-indigo-600">${totalVal} GB</td>`;
                 tr.innerHTML = rowHtml;
                 tbody.appendChild(tr);
             });

--- a/views/main.blade.php
+++ b/views/main.blade.php
@@ -13,88 +13,87 @@
     </style>
 </head>
 <body class="h-full text-slate-800 font-sans antialiased">
-    <div class="min-h-screen py-10 px-4 sm:px-6 lg:px-8 flex flex-col justify-between">
-        <div class="max-w-4xl w-full mx-auto bg-white rounded-2xl shadow-xl border border-slate-100 overflow-hidden mb-12">
+    <div class="min-h-screen py-3 sm:py-6 px-3 sm:px-6 lg:px-8 flex flex-col justify-between">
+        <div class="max-w-4xl w-full mx-auto bg-white rounded-2xl shadow-md border border-slate-100 overflow-hidden mb-4">
             <!-- Navigation Header -->
             @include('nav')
 
-            <div class="p-6 sm:p-10 space-y-8">
+            <div class="p-4 sm:p-6 space-y-5">
                 <!-- Loading Skeleton -->
-                <div id="loading-skeleton" class="space-y-6 animate-pulse">
-                    <div class="h-8 bg-slate-200 rounded-lg w-1/3"></div>
-                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                        <div class="h-24 bg-slate-100 rounded-xl"></div>
-                        <div class="h-24 bg-slate-100 rounded-xl"></div>
-                        <div class="h-24 bg-slate-100 rounded-xl"></div>
-                        <div class="h-24 bg-slate-100 rounded-xl"></div>
+                <div id="loading-skeleton" class="space-y-4 animate-pulse">
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                        <div class="h-20 bg-slate-100 rounded-xl"></div>
+                        <div class="h-20 bg-slate-100 rounded-xl"></div>
+                        <div class="h-20 bg-slate-100 rounded-xl"></div>
+                        <div class="h-20 bg-slate-100 rounded-xl"></div>
                     </div>
-                    <div class="h-64 bg-slate-100 rounded-2xl"></div>
-                    <div class="h-48 bg-slate-900/10 rounded-2xl"></div>
+                    <div class="h-60 bg-slate-100 rounded-2xl"></div>
+                    <div class="h-40 bg-slate-900/10 rounded-2xl"></div>
                 </div>
 
                 <!-- Error State -->
-                <div id="error-container" class="hidden p-6 bg-rose-50 border border-rose-200 text-rose-800 rounded-xl">
+                <div id="error-container" class="hidden p-4 bg-rose-50 border border-rose-200 text-rose-800 rounded-xl">
                     <div class="flex items-center gap-3">
-                        <svg class="w-6 h-6 text-rose-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <svg class="w-5 h-5 text-rose-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                         </svg>
                         <div>
-                            <h3 class="font-bold text-base">データの読み込みに失敗しました</h3>
-                            <p class="text-sm mt-1" id="error-message">通信エラーが発生しました。</p>
+                            <h3 class="font-bold text-sm">データの読み込みに失敗しました</h3>
+                            <p class="text-xs mt-0.5" id="error-message">通信エラーが発生しました。</p>
                         </div>
                     </div>
                 </div>
 
                 <!-- Content Container (Hidden until loaded) -->
-                <div id="content-container" class="hidden space-y-8">
+                <div id="content-container" class="hidden space-y-5">
                     <!-- Key Metric Cards -->
-                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                        <div class="bg-slate-50 border border-slate-100 p-4 rounded-xl">
+                    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+                        <div class="bg-slate-50 border border-slate-100 p-3 rounded-xl">
                             <span class="text-xs font-bold text-slate-400 uppercase tracking-wider block">今月合計使用量</span>
-                            <span class="text-2xl font-black text-slate-800 mt-1 block" id="card-this-month-total">-- GB</span>
+                            <span class="text-xl sm:text-2xl font-black text-slate-800 mt-0.5 block" id="card-this-month-total">-- GB</span>
                         </div>
-                        <div class="bg-slate-50 border border-slate-100 p-4 rounded-xl">
+                        <div class="bg-slate-50 border border-slate-100 p-3 rounded-xl">
                             <span class="text-xs font-bold text-slate-400 uppercase tracking-wider block">契約容量合計</span>
-                            <span class="text-2xl font-black text-indigo-600 mt-1 block" id="card-plan-data">-- GB</span>
+                            <span class="text-xl sm:text-2xl font-black text-indigo-600 mt-0.5 block" id="card-plan-data">-- GB</span>
                         </div>
-                        <div class="bg-slate-50 border border-slate-100 p-4 rounded-xl">
+                        <div class="bg-slate-50 border border-slate-100 p-3 rounded-xl">
                             <span class="text-xs font-bold text-slate-400 uppercase tracking-wider block">クーポン残量</span>
-                            <span class="text-2xl font-black text-emerald-600 mt-1 block" id="card-left-data">-- GB</span>
+                            <span class="text-xl sm:text-2xl font-black text-emerald-600 mt-0.5 block" id="card-left-data">-- GB</span>
                         </div>
-                        <div class="bg-slate-50 border border-slate-100 p-4 rounded-xl" id="card-surplus-box">
+                        <div class="bg-slate-50 border border-slate-100 p-3 rounded-xl" id="card-surplus-box">
                             <span class="text-xs font-bold text-slate-400 uppercase tracking-wider block">過不足予定</span>
-                            <span class="text-2xl font-black mt-1 block" id="card-surplus">-- GB</span>
+                            <span class="text-xl sm:text-2xl font-black mt-0.5 block" id="card-surplus">-- GB</span>
                         </div>
                     </div>
 
                     <!-- Usage & Prediction Chart Section -->
-                    <div class="bg-slate-50/60 p-6 rounded-2xl border border-slate-100 space-y-6">
-                        <div class="border-b border-slate-200/60 pb-3 flex items-center justify-between">
-                            <div class="flex items-center gap-2.5">
-                                <svg class="w-5 h-5 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                    <div class="bg-slate-50/60 p-4 sm:p-5 rounded-2xl border border-slate-100 space-y-4">
+                        <div class="border-b border-slate-200/60 pb-2.5 flex items-center justify-between">
+                            <div class="flex items-center gap-2">
+                                <svg class="w-4 h-4 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
                                 </svg>
-                                <h2 class="text-lg font-extrabold text-slate-800">全体使用量 ＆ 月末着地点予測</h2>
+                                <h2 class="text-base font-extrabold text-slate-800">全体使用量 ＆ 月末着地点予測</h2>
                             </div>
                         </div>
 
-                        <div class="relative h-72 sm:h-80 flex justify-center items-center">
+                        <div class="relative h-64 sm:h-72 flex justify-center items-center">
                             <canvas id="landingChart"></canvas>
                         </div>
                     </div>
 
                     <!-- User Breakdown Table -->
-                    <div class="bg-slate-50/60 p-6 rounded-2xl border border-slate-100 space-y-4">
-                        <h3 class="text-md font-extrabold text-slate-800">ユーザー別利用詳細</h3>
+                    <div class="bg-slate-50/60 p-4 sm:p-5 rounded-2xl border border-slate-100 space-y-3">
+                        <h3 class="text-sm font-extrabold text-slate-800">ユーザー別利用詳細</h3>
                         <div class="overflow-x-auto border border-slate-200/80 rounded-xl bg-white shadow-sm">
-                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <table class="min-w-full divide-y divide-slate-200 text-xs sm:text-sm">
                                 <thead class="bg-slate-50">
                                     <tr>
-                                        <th scope="col" class="px-4 py-3 text-left font-bold text-slate-500">ユーザー名</th>
-                                        <th scope="col" class="px-4 py-3 text-right font-bold text-slate-500">当月使用量</th>
-                                        <th scope="col" class="px-4 py-3 text-right font-bold text-slate-500">本日増加量</th>
-                                        <th scope="col" class="px-4 py-3 text-right font-bold text-slate-500">月末予測</th>
-                                        <th scope="col" class="px-4 py-3 text-right font-bold text-slate-500">契約容量</th>
+                                        <th scope="col" class="px-3.5 py-2.5 text-left font-bold text-slate-500">ユーザー名</th>
+                                        <th scope="col" class="px-3.5 py-2.5 text-right font-bold text-slate-500">当月使用量</th>
+                                        <th scope="col" class="px-3.5 py-2.5 text-right font-bold text-slate-500">本日増加量</th>
+                                        <th scope="col" class="px-3.5 py-2.5 text-right font-bold text-slate-500">月末予測</th>
+                                        <th scope="col" class="px-3.5 py-2.5 text-right font-bold text-slate-500">契約容量</th>
                                     </tr>
                                 </thead>
                                 <tbody id="user-breakdown-body" class="divide-y divide-slate-200">
@@ -104,22 +103,18 @@
                     </div>
 
                     <!-- LINE Notification Report -->
-                    <div class="bg-slate-900 rounded-2xl border border-slate-800 shadow-xl overflow-hidden">
-                        <div class="bg-slate-800/80 px-5 py-3.5 border-b border-slate-700/50 flex items-center justify-between">
+                    <div class="bg-slate-900 rounded-2xl border border-slate-800 shadow-lg overflow-hidden">
+                        <div class="bg-slate-800/80 px-4 py-2.5 border-b border-slate-700/50 flex items-center justify-between">
                             <div class="flex items-center gap-2">
-                                <span class="w-3 h-3 rounded-full bg-emerald-500"></span>
-                                <span class="text-slate-200 text-sm font-bold">LINE通知レポートの内容</span>
+                                <span class="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>
+                                <span class="text-slate-200 text-xs font-bold">LINE通知レポートの内容</span>
                             </div>
-                            <span class="text-slate-400 text-xs font-mono uppercase tracking-wider">Report</span>
+                            <span class="text-slate-400 text-[10px] font-mono uppercase tracking-wider">Report</span>
                         </div>
-                        <pre id="line-report-text" class="p-5 overflow-x-auto text-emerald-400 font-mono text-sm leading-relaxed whitespace-pre-wrap select-all"></pre>
+                        <pre id="line-report-text" class="p-4 overflow-x-auto text-emerald-400 font-mono text-xs leading-relaxed whitespace-pre-wrap select-all"></pre>
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div class="text-center text-xs text-slate-400 font-medium pb-4">
-            IIJmio Usage Checker &bull; Environment: <span class="px-2 py-0.5 rounded bg-slate-200 text-slate-600 font-mono">{{ $appEnv }}</span>
         </div>
     </div>
 
@@ -161,9 +156,9 @@
             const surplusEl = document.getElementById('card-surplus');
             surplusEl.textContent = (shortageOrSurplus >= 0 ? '+' : '') + shortageOrSurplus + ' GB';
             if (shortageOrSurplus >= 0) {
-                surplusEl.className = 'text-2xl font-black text-emerald-600 mt-1 block';
+                surplusEl.className = 'text-xl sm:text-2xl font-black text-emerald-600 mt-0.5 block';
             } else {
-                surplusEl.className = 'text-2xl font-black text-rose-600 mt-1 block';
+                surplusEl.className = 'text-xl sm:text-2xl font-black text-rose-600 mt-0.5 block';
             }
 
             // User breakdown table
@@ -174,11 +169,11 @@
                     const tr = document.createElement('tr');
                     tr.className = 'hover:bg-slate-50/50 transition-colors';
                     tr.innerHTML = `
-                        <td class="px-4 py-3 font-semibold text-slate-800">${u.name}</td>
-                        <td class="px-4 py-3 text-right text-slate-700">${u.currentUsage} GB</td>
-                        <td class="px-4 py-3 text-right text-slate-500">+${u.dailyUsage} GB</td>
-                        <td class="px-4 py-3 text-right font-bold text-indigo-600">${u.estimatedUserUsage} GB</td>
-                        <td class="px-4 py-3 text-right text-slate-500">${u.planDataVolume} GB</td>
+                        <td class="px-3.5 py-2.5 font-semibold text-slate-800">${u.name}</td>
+                        <td class="px-3.5 py-2.5 text-right text-slate-700">${u.currentUsage} GB</td>
+                        <td class="px-3.5 py-2.5 text-right text-slate-500">+${u.dailyUsage} GB</td>
+                        <td class="px-3.5 py-2.5 text-right font-bold text-indigo-600">${u.estimatedUserUsage} GB</td>
+                        <td class="px-3.5 py-2.5 text-right text-slate-500">${u.planDataVolume} GB</td>
                     `;
                     tbody.appendChild(tr);
                 });
@@ -232,7 +227,7 @@
                         title: {
                             display: true,
                             text: '月末着地点予測 (GB)',
-                            font: { size: 15, weight: 'bold' }
+                            font: { size: 14, weight: 'bold' }
                         }
                     },
                     scales: {

--- a/views/monthly.blade.php
+++ b/views/monthly.blade.php
@@ -10,60 +10,60 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="h-full text-slate-800 font-sans antialiased">
-    <div class="min-h-screen py-10 px-4 sm:px-6 lg:px-8 flex flex-col justify-between">
-        <div class="max-w-4xl w-full mx-auto bg-white rounded-2xl shadow-xl border border-slate-100 overflow-hidden mb-12">
+    <div class="min-h-screen py-3 sm:py-6 px-3 sm:px-6 lg:px-8 flex flex-col justify-between">
+        <div class="max-w-4xl w-full mx-auto bg-white rounded-2xl shadow-md border border-slate-100 overflow-hidden mb-4">
             <!-- Navigation Header -->
             @include('nav')
 
-            <div class="p-6 sm:p-10 space-y-8">
+            <div class="p-4 sm:p-6 space-y-5">
                 <!-- Transition Banner to Daily View -->
-                <div class="flex flex-col sm:flex-row items-center justify-between gap-4 p-4 bg-indigo-50 border border-indigo-100 rounded-xl">
-                    <div class="text-sm font-medium text-indigo-900">
-                        月ごとの個人別利用量グラフを表示しています。日ごとの詳細を見るには日別グラフへお進みください。
+                <div class="flex flex-col sm:flex-row items-center justify-between gap-3 p-3.5 bg-indigo-50 border border-indigo-100 rounded-xl">
+                    <div class="text-xs sm:text-sm font-medium text-indigo-900">
+                        月ごとの個人別利用量グラフを表示しています。日ごとの詳細を見るには日別画面へお進みください。
                     </div>
-                    <a href="?page=daily" class="shrink-0 inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs rounded-lg transition active:scale-95 shadow-sm">
-                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+                    <a href="?page=daily" class="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-bold text-xs rounded-lg transition active:scale-95 shadow-sm">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
                         </svg>
-                        日別グラフ画面へ
+                        日別画面へ
                     </a>
                 </div>
 
                 <!-- Loading Skeleton -->
-                <div id="loading-skeleton" class="space-y-6 animate-pulse">
+                <div id="loading-skeleton" class="space-y-4 animate-pulse">
                     <div class="h-8 bg-slate-200 rounded-lg w-1/3"></div>
                     <div class="h-80 bg-slate-100 rounded-2xl"></div>
                 </div>
 
                 <!-- Error Container -->
-                <div id="error-container" class="hidden p-6 bg-rose-50 border border-rose-200 text-rose-800 rounded-xl">
+                <div id="error-container" class="hidden p-4 bg-rose-50 border border-rose-200 text-rose-800 rounded-xl">
                     <div class="flex items-center gap-3">
-                        <svg class="w-6 h-6 text-rose-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <svg class="w-5 h-5 text-rose-600 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                         </svg>
                         <div>
-                            <h3 class="font-bold text-base">履歴データの読み込みに失敗しました</h3>
-                            <p class="text-sm mt-1" id="error-message">通信エラーが発生しました。</p>
+                            <h3 class="font-bold text-sm">履歴データの読み込みに失敗しました</h3>
+                            <p class="text-xs mt-0.5" id="error-message">通信エラーが発生しました。</p>
                         </div>
                     </div>
                 </div>
 
                 <!-- Content Container -->
-                <div id="content-container" class="hidden space-y-8">
-                    <div class="bg-slate-50/60 p-6 rounded-2xl border border-slate-100 space-y-4">
-                        <div class="flex items-center justify-between border-b border-slate-200/60 pb-3">
-                            <h2 class="text-lg font-extrabold text-slate-800">月別・個人別使用量 (GB)</h2>
+                <div id="content-container" class="hidden space-y-5">
+                    <div class="bg-slate-50/60 p-4 sm:p-5 rounded-2xl border border-slate-100 space-y-4">
+                        <div class="flex items-center justify-between border-b border-slate-200/60 pb-2.5">
+                            <h2 class="text-base font-extrabold text-slate-800">月別・個人別使用量 (GB)</h2>
                         </div>
-                        <div class="relative h-80 sm:h-96">
+                        <div class="relative h-72 sm:h-80">
                             <canvas id="monthlyChart"></canvas>
                         </div>
                     </div>
 
                     <!-- History Table -->
-                    <div class="bg-slate-50/60 p-6 rounded-2xl border border-slate-100 space-y-4">
-                        <h3 class="text-md font-extrabold text-slate-800">月別使用量 集計テーブル</h3>
+                    <div class="bg-slate-50/60 p-4 sm:p-5 rounded-2xl border border-slate-100 space-y-3">
+                        <h3 class="text-sm font-extrabold text-slate-800">月別使用量 集計テーブル</h3>
                         <div class="overflow-x-auto border border-slate-200/80 rounded-xl bg-white shadow-sm">
-                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <table class="min-w-full divide-y divide-slate-200 text-xs sm:text-sm">
                                 <thead class="bg-slate-50" id="monthly-table-head">
                                 </thead>
                                 <tbody id="monthly-table-body" class="divide-y divide-slate-200">
@@ -73,10 +73,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-
-        <div class="text-center text-xs text-slate-400 font-medium pb-4">
-            IIJmio Usage Checker &bull; Environment: <span class="px-2 py-0.5 rounded bg-slate-200 text-slate-600 font-mono">{{ $appEnv }}</span>
         </div>
     </div>
 
@@ -145,11 +141,11 @@
 
             // Table rendering
             const thead = document.getElementById('monthly-table-head');
-            let headHtml = `<tr><th class="px-4 py-3 text-left font-bold text-slate-500">年月</th>`;
+            let headHtml = `<tr><th class="px-3.5 py-2.5 text-left font-bold text-slate-500">年月</th>`;
             userKeys.forEach(k => {
-                headHtml += `<th class="px-4 py-3 text-right font-bold text-slate-500">${users[k]}</th>`;
+                headHtml += `<th class="px-3.5 py-2.5 text-right font-bold text-slate-500">${users[k]}</th>`;
             });
-            headHtml += `<th class="px-4 py-3 text-right font-bold text-slate-700">合計</th></tr>`;
+            headHtml += `<th class="px-3.5 py-2.5 text-right font-bold text-slate-700">合計</th></tr>`;
             thead.innerHTML = headHtml;
 
             const tbody = document.getElementById('monthly-table-body');
@@ -157,11 +153,11 @@
             monthlyData.slice().reverse().forEach(row => {
                 const tr = document.createElement('tr');
                 tr.className = 'hover:bg-slate-50/50 transition-colors';
-                let rowHtml = `<td class="px-4 py-3 font-semibold text-slate-800">${row.month}</td>`;
+                let rowHtml = `<td class="px-3.5 py-2.5 font-semibold text-slate-800">${row.month}</td>`;
                 userKeys.forEach(k => {
-                    rowHtml += `<td class="px-4 py-3 text-right text-slate-600">${row.usages[k] ?? 0} GB</td>`;
+                    rowHtml += `<td class="px-3.5 py-2.5 text-right text-slate-600">${row.usages[k] ?? 0} GB</td>`;
                 });
-                rowHtml += `<td class="px-4 py-3 text-right font-bold text-indigo-600">${row.total} GB</td>`;
+                rowHtml += `<td class="px-3.5 py-2.5 text-right font-bold text-indigo-600">${row.total} GB</td>`;
                 tr.innerHTML = rowHtml;
                 tbody.appendChild(tr);
             });

--- a/views/nav.blade.php
+++ b/views/nav.blade.php
@@ -1,46 +1,26 @@
-<div class="bg-gradient-to-r from-blue-600 to-indigo-700 px-6 py-6 sm:px-10 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-    <div>
-        <h1 class="text-2xl sm:text-3xl font-extrabold text-white tracking-tight">IIJmio Usage Checker</h1>
-        <p class="text-blue-100 mt-1 text-sm font-medium">データ利用状況・予測ダッシュボード</p>
-    </div>
-    <div class="flex flex-wrap gap-2 items-center">
-        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold bg-white/20 text-white backdrop-blur-sm border border-white/10">
-            <span class="w-2 h-2 rounded-full bg-blue-300 animate-pulse"></span>
-            {{ $collectionName }}
-        </span>
-        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold
-              @if($appEnv === 'production') bg-red-500/25 text-red-100 border border-red-500/30
-              @elseif($appEnv === 'test') bg-amber-500/25 text-amber-100 border border-amber-500/30
-              @else bg-slate-500/25 text-slate-100 border border-slate-500/30
-              @endif backdrop-blur-sm uppercase">
-            {{ $appEnv }}
-        </span>
-    </div>
-</div>
-
 <!-- Navigation Tabs -->
-<div class="bg-slate-800 border-b border-slate-700/80 px-4 sm:px-8">
-    <nav class="flex flex-wrap -mb-px space-x-2 sm:space-x-6 text-sm font-bold" aria-label="Tabs">
-        <a href="?page=main" class="inline-flex items-center gap-2 py-3.5 px-3 border-b-2 font-medium text-sm transition-colors {{ ($currentPage ?? 'main') === 'main' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+<div class="bg-slate-800 border-b border-slate-700/80 px-3 sm:px-6">
+    <nav class="flex flex-nowrap overflow-x-auto whitespace-nowrap space-x-1 sm:space-x-4 text-sm font-bold" aria-label="Tabs">
+        <a href="?page=main" class="inline-flex items-center gap-1.5 py-3 px-2.5 sm:px-3 border-b-2 font-medium text-sm transition-colors shrink-0 {{ ($currentPage ?? 'main') === 'main' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1h3a1 1 0 001-1V10M9 21h6" />
             </svg>
             メイン
         </a>
-        <a href="?page=daily" class="inline-flex items-center gap-2 py-3.5 px-3 border-b-2 font-medium text-sm transition-colors {{ ($currentPage ?? '') === 'daily' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <a href="?page=daily" class="inline-flex items-center gap-1.5 py-3 px-2.5 sm:px-3 border-b-2 font-medium text-sm transition-colors shrink-0 {{ ($currentPage ?? '') === 'daily' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
-            日別グラフ
+            日別
         </a>
-        <a href="?page=monthly" class="inline-flex items-center gap-2 py-3.5 px-3 border-b-2 font-medium text-sm transition-colors {{ ($currentPage ?? '') === 'monthly' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <a href="?page=monthly" class="inline-flex items-center gap-1.5 py-3 px-2.5 sm:px-3 border-b-2 font-medium text-sm transition-colors shrink-0 {{ ($currentPage ?? '') === 'monthly' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
             </svg>
-            月別グラフ
+            月別
         </a>
-        <a href="?page=config" class="inline-flex items-center gap-2 py-3.5 px-3 border-b-2 font-medium text-sm transition-colors {{ ($currentPage ?? '') === 'config' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
-            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <a href="?page=config" class="inline-flex items-center gap-1.5 py-3 px-2.5 sm:px-3 border-b-2 font-medium text-sm transition-colors shrink-0 {{ ($currentPage ?? '') === 'config' ? 'border-indigo-400 text-indigo-300 font-extrabold' : 'border-transparent text-slate-400 hover:text-slate-200 hover:border-slate-500' }}">
+            <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>


### PR DESCRIPTION
メイン画面のヘッダ領域・タイトルの整理と縦長レイアウトの改善、ナビゲーションメニューの1行表示化、および日別グラフにおける「日ごと」「累積」切替機能と累積モード時の月末予測トレンドライン描画機能を実装しました。

Fixes #76

---
*PR created automatically by Jules for task [4896815619318527838](https://jules.google.com/task/4896815619318527838) started by @yananob*